### PR TITLE
Added claude gemini open ai models

### DIFF
--- a/model_pricing.json
+++ b/model_pricing.json
@@ -943,7 +943,7 @@
             "gemini-3.1-flash-image-preview": [
                 "image",
                 "image-gen"
-            ],
+            ]
         },
         "openrouter_identifier": {
             "gemini-1.5-pro-latest": "google/gemini-pro-1.5",
@@ -1043,7 +1043,7 @@
             "gemini-3-pro-preview": "Google’s latest flagship Gemini model with advanced reasoning",
             "gemini-3-flash": "Fast and lightweight Gemini 3 model optimized for low latency",
             "gemini-3-pro-image-preview": "Google's latest Pro image model (Nano Banana Pro)",
-            "gemini-3.1-pro-preview": "Google's latest and most advanced Gemini model with improved reasoning and creativity"
+            "gemini-3.1-pro-preview": "Google's latest and most advanced Gemini model with improved reasoning and creativity",
             "gemini-3.1-flash-image-preview": "Google's latest fast image model (Nano Banana 2)"
         },
         "alias": {

--- a/model_pricing.json
+++ b/model_pricing.json
@@ -247,14 +247,16 @@
                 "image",
                 "reasoning",
                 "search",
-                "mcp"
+                "mcp",
+                "agent"
             ],
             "gpt-5.4": [
                 "reasoning",
                 "image",
                 "search",
                 "pdf",
-                "mcp"
+                "mcp",
+                "agent"
             ]
         },
         "openrouter_identifier": {
@@ -691,13 +693,15 @@
                 "image",
                 "pdf",
                 "computer-use",
-                "reasoning"
+                "reasoning",
+                "agent"
             ],
             "claude-opus-4-6": [
                 "image",
                 "pdf",
                 "computer-use",
-                "reasoning"
+                "reasoning",
+                "agent"
             ]
         },
         "openrouter_identifier": {
@@ -861,13 +865,13 @@
             "gemini-1.5-pro-latest",
             "gemini-1.5-flash-latest",
             "gemini-2.0-flash",
+            "gemini-2.0-flash-001",
             "gemini-2.5-flash",
             "gemini-2.5-pro",
             "gemini-2.5-flash-image-preview",
             "gemini-3-pro-preview",
-            "gemini-3-flash-preview",
+            "gemini-3-flash",
             "gemini-3-pro-image-preview",
-            "gemini-2.0-flash-001",
             "gemini-3.1-pro-preview"
         ],
         "api_key": "GOOGLE_GENERATIVE_AI_API_KEY",
@@ -879,6 +883,12 @@
             "gemini-1.5-flash-latest": [
                 "routing",
                 "image",
+                "search"
+            ],
+            "gemini-2.0-flash-001": [
+                "routing",
+                "image",
+                "pdf",
                 "search"
             ],
             "gemini-2.0-flash": [
@@ -898,16 +908,16 @@
                 "image",
                 "image-gen"
             ],
-            "gemini-3-pro-image-preview": [
-                "image",
-                "image-gen"
-            ],
             "gemini-2.5-pro": [
                 "routing",
                 "image",
                 "pdf",
                 "search",
                 "reasoning"
+            ],
+            "gemini-3-pro-image-preview": [
+                "image",
+                "image-gen"
             ],
             "gemini-3-pro-preview": [
                 "routing",
@@ -916,23 +926,19 @@
                 "search",
                 "reasoning"
             ],
-            "gemini-3-flash-preview": [
+            "gemini-3-flash": [
                 "routing",
                 "image",
                 "search",
-                "reasoning"
-            ],
-            "gemini-2.0-flash-001": [
-                "routing",
-                "image",
-                "pdf",
-                "search"
+                "reasoning",
+                "agent"
             ],
             "gemini-3.1-pro-preview": [
                 "pdf",
                 "image",
                 "search",
-                "reasoning"
+                "reasoning",
+                "agent"
             ]
         },
         "openrouter_identifier": {
@@ -999,11 +1005,11 @@
             "gemini-1.5-pro-latest": "Gemini-1.5 Pro",
             "gemini-2.0-flash": "Gemini-2.0 Flash",
             "gemini-2.5-flash": "Gemini-2.5 Flash",
-            "gemini-2.5-flash-image-preview": "Gemini-2.5 Flash Image",
+            "gemini-2.5-flash-image-preview": "Nano Banana",
             "gemini-2.5-pro": "Gemini-2.5 Pro",
             "gemini-3-pro-preview": "Gemini-3 Pro",
             "gemini-3-flash-preview": "Gemini-3 Flash",
-            "gemini-3-pro-image-preview": "Gemini-3 Pro Image",
+            "gemini-3-pro-image-preview": "Nano Banana Pro",
             "gemini-3.1-pro-preview": "Gemini-3.1 Pro"
         },
         "availableForChatApp": {
@@ -1023,10 +1029,10 @@
             "gemini-2.0-flash": "Google's latest stable model",
             "gemini-2.5-flash": "Google's latest fastest model",
             "gemini-2.5-pro": "Google's newest experimental model",
-            "gemini-2.5-flash-image-preview": "Google's newest img model (nanobanana)",
+            "gemini-2.5-flash-image-preview": "Google's newest img model (Nano Banana)",
             "gemini-3-pro-preview": "Google’s latest flagship Gemini model with advanced reasoning",
             "gemini-3-flash-preview": "Fast and lightweight Gemini 3 model optimized for low latency",
-            "gemini-3-pro-image-preview": "Google's latest image model (megabanana)",
+            "gemini-3-pro-image-preview": "Google's latest image model (Nano Banana 2)",
             "gemini-3.1-pro-preview": "Google's latest and most advanced Gemini model with improved reasoning and creativity"
         },
         "alias": {

--- a/model_pricing.json
+++ b/model_pricing.json
@@ -872,7 +872,8 @@
             "gemini-3-pro-preview",
             "gemini-3-flash",
             "gemini-3-pro-image-preview",
-            "gemini-3.1-pro-preview"
+            "gemini-3.1-pro-preview",
+            "gemini-3.1-flash-image-preview"
         ],
         "api_key": "GOOGLE_GENERATIVE_AI_API_KEY",
         "capabilities": {
@@ -956,7 +957,8 @@
             "gemini-3-pro-image-preview": "google/gemini-3-pro-image-preview",
             "gemini-2.5-flash-image-preview": "google/gemini-2.5-flash-image-preview",
             "gemini-2.0-flash-001": "google/gemini-2.0-flash-001",
-            "gemini-3.1-pro-preview": "google/gemini-3.1-pro-preview"
+            "gemini-3.1-pro-preview": "google/gemini-3.1-pro-preview",
+            "gemini-3.1-flash-image-preview": "google/gemini-3.1-flash-image-preview"
         },
         "price": {
             "gemini-1.5-pro-latest": {

--- a/model_pricing.json
+++ b/model_pricing.json
@@ -294,7 +294,9 @@
             "gpt-5.1-2025-11-13": "openai/gpt-5.1",
             "gpt-5.2-2025-12-11": "openai/gpt-5.2",
             "gpt-5.2-pro": "openai/gpt-5.2-pro",
-            "gpt-5.2-pro-2025-12-11": "openai/gpt-5.2-pro"
+            "gpt-5.2-pro-2025-12-11": "openai/gpt-5.2-pro",
+            "gpt-5.3-codex": "openai/gpt-5.3-codex",
+            "gpt-5.4": "openai/gpt-5.4"
         },
         "price": {
             "gpt-3.5-turbo": {
@@ -988,8 +990,8 @@
                 "output": 0.6
             },
             "gemini-3.1-pro-preview": {
-                "input": 0.779,
-                "output": 12.02
+                "input": 2,
+                "output": 12
             }
         },
         "name": {

--- a/model_pricing.json
+++ b/model_pricing.json
@@ -47,7 +47,8 @@
             "gpt-5.1-2025-11-13",
             "gpt-5.2-2025-12-11",
             "gpt-5.2-pro",
-            "gpt-5.2-pro-2025-12-11"
+            "gpt-5.2-pro-2025-12-11",
+            "gpt-5.3-codex"
         ],
         "api_key": "OPENAI_API_KEY",
         "capabilities": {
@@ -238,6 +239,13 @@
             "gpt-5.2-pro-2025-12-11": [
                 "reasoning",
                 "image",
+                "search",
+                "mcp"
+            ],
+            "gpt-5.3-codex": [
+                "text",
+                "image",
+                "reasoning",
                 "search",
                 "mcp"
             ]
@@ -449,6 +457,10 @@
             "gpt-5.2-pro-2025-12-11": {
                 "input": 21,
                 "output": 168
+            },
+            "gpt-5.3-codex": {
+                "input": 1.75,
+                "output": 14
             }
         },
         "name": {
@@ -467,7 +479,8 @@
             "gpt-5.1-chat-latest": "GPT-5.1 Chat",
             "gpt-5.2": "GPT-5.2",
             "gpt-5.2-chat-latest": "GPT-5.2 Chat",
-            "gpt-5.2-pro": "GPT-5.2 Pro"
+            "gpt-5.2-pro": "GPT-5.2 Pro",
+            "gpt-5.3-codex": "GPT-5.3 Codex"
         },
         "availableForChatApp": {
             "gpt-4o-mini": "Free",
@@ -485,7 +498,8 @@
             "gpt-5.1-chat-latest": "Pro",
             "gpt-5.2": "Pro",
             "gpt-5.2-chat-latest": "Pro",
-            "gpt-5.2-pro": "Pro"
+            "gpt-5.2-pro": "Pro",
+            "gpt-5.3-codex": "Pro"
         },
         "descriptions": {
             "gpt-4o-mini": "Faster, less precise GPT-4o",
@@ -503,7 +517,8 @@
             "gpt-5.1-chat-latest": "OpenAI's Next-Gen Chat Model",
             "gpt-5.2": "OpenAI's Next-Gen Model",
             "gpt-5.2-chat-latest": "OpenAI's Next-Gen Chat Model",
-            "gpt-5.2-pro": "OpenAI's most capable reasoning model"
+            "gpt-5.2-pro": "OpenAI's most capable reasoning model",
+            "gpt-5.3-codex": "OpenAI's most capable agentic coding model to date."
         },
         "alias": {
             "gpt-4o-2024-11-20": "gpt-4o",
@@ -542,7 +557,9 @@
             "claude-haiku-4-5-20251001",
             "claude-sonnet-4-5-20250929",
             "claude-opus-4-5-20251101",
-            "claude-opus-4-1-20250805"
+            "claude-opus-4-1-20250805",
+            "claude-sonnet-4-6",
+            "claude-opus-4-6"
         ],
         "api_key": "ANTHROPIC_API_KEY",
         "capabilities": {
@@ -653,6 +670,20 @@
                 "pdf",
                 "computer-use",
                 "reasoning"
+            ],
+            "claude-sonnet-4-6": [
+                "routing",
+                "image",
+                "pdf",
+                "computer-use",
+                "reasoning"
+            ],
+            "claude-opus-4-6": [
+                "routing",
+                "image",
+                "pdf",
+                "computer-use",
+                "reasoning"
             ]
         },
         "openrouter_identifier": {
@@ -751,6 +782,14 @@
             "claude-opus-4-1-20250805": {
                 "input": 15,
                 "output": 75
+            },
+            "claude-sonnet-4-6": {
+                "input": 3,
+                "output": 15
+            },
+            "claude-opus-4-6": {
+                "input": 5,
+                "output": 25
             }
         },
         "name": {
@@ -760,7 +799,9 @@
             "claude-sonnet-4-20250514": "Claude-4 Sonnet",
             "claude-haiku-4-5-20251001": "Claude-4.5 Haiku",
             "claude-sonnet-4-5-20250929": "Claude-4.5 Sonnet",
-            "claude-opus-4-5-20251101": "Claude-4.5 Opus"
+            "claude-opus-4-5-20251101": "Claude-4.5 Opus",
+            "claude-sonnet-4-6": "Claude-4.6 Sonnet",
+            "claude-opus-4-6": "Claude-4.6 Opus"
         },
         "availableForChatApp": {
             "claude-3-haiku-20240307": "Free",
@@ -769,7 +810,9 @@
             "claude-sonnet-4-20250514": "Pro",
             "claude-haiku-4-5-20251001": "Pro",
             "claude-sonnet-4-5-20250929": "Pro",
-            "claude-opus-4-5-20251101": "Pro"
+            "claude-opus-4-5-20251101": "Pro",
+            "claude-sonnet-4-6": "Pro",
+            "claude-opus-4-6": "Pro"
         },
         "alias": {
             "claude-3-5-haiku-20241022": "claude-3-5-haiku",
@@ -777,7 +820,9 @@
             "claude-sonnet-4-5-20250929": "claude-sonnet-4-5",
             "claude-opus-4-5-20251101": "claude-opus-4-5",
             "claude-haiku-4-5-20251001": "claude-haiku-4-5",
-            "claude-opus-4-1-20250805": "claude-opus-4-1"
+            "claude-opus-4-1-20250805": "claude-opus-4-1",
+            "claude-sonnet-4-6": "claude-sonnet-4-6",
+            "claude-opus-4-6": "claude-opus-4-6"
         },
         "descriptions": {
             "claude-3-haiku-20240307": "Anthropic's previous fastest model",
@@ -786,7 +831,9 @@
             "claude-sonnet-4-20250514": "Anthropic's Flagship Model",
             "claude-haiku-4-5-20251001": "Fast and affordable Claude 4.5 model for lightweight tasks",
             "claude-sonnet-4-5-20250929": "Balanced Claude 4.5 model optimized for reasoning and reliability",
-            "claude-opus-4-5-20251101": "Anthropic’s most powerful Claude model for complex reasoning"
+            "claude-opus-4-5-20251101": "Anthropic’s most powerful Claude model for complex reasoning",
+            "claude-sonnet-4-6": "The best combination of speed and intelligence",
+            "claude-opus-4-6": "The most intelligent model for building agents and coding"
         }
     },
     "google": {
@@ -806,7 +853,8 @@
             "gemini-3-pro-preview",
             "gemini-3-flash-preview",
             "gemini-3-pro-image-preview",
-            "gemini-2.0-flash-001"
+            "gemini-2.0-flash-001",
+            "gemini-3.1-pro-preview"
         ],
         "api_key": "GOOGLE_GENERATIVE_AI_API_KEY",
         "capabilities": {
@@ -865,6 +913,13 @@
                 "image",
                 "pdf",
                 "search"
+            ],
+            "gemini-3.1-pro-preview": [
+                "text",
+                "pdf",
+                "image",
+                "search",
+                "reasoning"
             ]
         },
         "openrouter_identifier": {
@@ -919,6 +974,10 @@
             "gemini-2.0-flash-001": {
                 "input": 0.15,
                 "output": 0.6
+            },
+            "gemini-3.1-pro-preview": {
+                "input": 0.779,
+                "output": 12.02
             }
         },
         "name": {
@@ -930,7 +989,8 @@
             "gemini-2.5-pro": "Gemini-2.5 Pro",
             "gemini-3-pro-preview": "Gemini-3 Pro",
             "gemini-3-flash-preview": "Gemini-3 Flash",
-            "gemini-3-pro-image-preview": "Gemini-3 Pro Image"
+            "gemini-3-pro-image-preview": "Gemini-3 Pro Image",
+            "gemini-3.1-pro-preview": "Gemini-3.1 Pro"
         },
         "availableForChatApp": {
             "gemini-1.5-pro-latest": "Pro",
@@ -940,7 +1000,8 @@
             "gemini-2.5-flash-image-preview": "Pro",
             "gemini-3-flash-preview": "Free",
             "gemini-3-pro-preview": "Pro",
-            "gemini-3-pro-image-preview": "Pro"
+            "gemini-3-pro-image-preview": "Pro",
+            "gemini-3.1-pro-preview": "Pro"
         },
         "descriptions": {
             "gemini-1.5-flash-latest": "Faster & less precise Gemini-1.5 Pro",
@@ -951,7 +1012,8 @@
             "gemini-2.5-flash-image-preview": "Google's newest img model (nanobanana)",
             "gemini-3-pro-preview": "Google’s latest flagship Gemini model with advanced reasoning",
             "gemini-3-flash-preview": "Fast and lightweight Gemini 3 model optimized for low latency",
-            "gemini-3-pro-image-preview": "Google's latest image model (megabanana)"
+            "gemini-3-pro-image-preview": "Google's latest image model (megabanana)",
+            "gemini-3.1-pro-preview": "Google's latest and most advanced Gemini model with improved reasoning and creativity"
         },
         "alias": {
             "gemini-2.0-flash-001": "gemini-2.0-flash"

--- a/model_pricing.json
+++ b/model_pricing.json
@@ -689,13 +689,15 @@
                 "image",
                 "pdf",
                 "computer-use",
-                "reasoning"
+                "reasoning",
+                "routing"
             ],
             "claude-opus-4-6": [
                 "image",
                 "pdf",
                 "computer-use",
-                "reasoning"
+                "reasoning",
+                "routing"
             ]
         },
         "openrouter_identifier": {

--- a/model_pricing.json
+++ b/model_pricing.json
@@ -1158,8 +1158,7 @@
             "DeepSeek-R1",
             "Kimi-K2-Thinking",
             "Qwen3-30B-A3B",
-            "Qwen-Image",
-            "GLM-Image"
+            "Qwen-Image"
         ],
         "api_key": "TOGETHER_AI_API_KEY",
         "model_prefix": {
@@ -1175,8 +1174,7 @@
             "DeepSeek-R1": "deepseek-ai",
             "Kimi-K2-Thinking": "moonshotai",
             "Qwen3-30B-A3B": "Qwen",
-            "Qwen-Image": "Qwen",
-            "GLM-Image": "zai-org"
+            "Qwen-Image": "Qwen"
         },
         "capabilities": {
             "DeepSeek-R1": [
@@ -1195,9 +1193,6 @@
             ],
             "Qwen-Image": [
                 "image-gen"
-            ],
-            "GLM-Image": [
-                "image-gen"
             ]
         },
         "openrouter_identifier": {
@@ -1213,8 +1208,7 @@
             "DeepSeek-R1": "deepseek/deepseek-r1",
             "Kimi-K2-Thinking": "moonshotai/kimi-k2-thinking",
             "Qwen3-30B-A3B": "Qwen/qwen3-30B-A3B",
-            "Qwen-Image": "Qwen/Qwen-Image",
-            "GLM-Image": "zai-org/glm-image"
+            "Qwen-Image": "Qwen/Qwen-Image"
         },
         "price": {
             "Mistral-7B-Instruct-v0.2": {
@@ -1268,10 +1262,6 @@
             "Qwen-Image": {
                 "input": 0,
                 "output": 75
-            },
-            "GLM-Image": {
-                "input": 0,
-                "output": 15
             }
         },
         "name": {
@@ -1279,24 +1269,21 @@
             "DeepSeek-R1": "DeepSeek-R1",
             "Kimi-K2-Thinking": "Kimi-K2-Thinking",
             "Qwen3-30B-A3B": "Qwen-3-30B",
-            "Qwen-Image": "Qwen-Image",
-            "GLM-Image": "GLM-Image (Zhipu)"
+            "Qwen-Image": "Qwen-Image"
         },
         "availableForChatApp": {
             "Meta-Llama-3.1-70B-Instruct-Turbo": "Free",
             "DeepSeek-R1": "Pro",
             "Kimi-K2-Thinking": "Pro",
             "Qwen3-30B-A3B": "Pro",
-            "Qwen-Image": "Pro",
-            "GLM-Image": "Pro"
+            "Qwen-Image": "Pro"
         },
         "descriptions": {
             "Meta-Llama-3.1-70B-Instruct-Turbo": "Meta's 70B flagship model",
             "DeepSeek-R1": "DeepSeek's Reasoning Model",
             "Kimi-K2-Thinking": "Open-source agentic reasoning model with deep multi-step planning and tool use",
             "Qwen3-30B-A3B": "Qwen3 hybrid reasoning model with large context and multilingual support",
-            "Qwen-Image": "A 20B MMDiT image foundation model that achieves significant advances in complex text rendering and precise image editing.",
-            "GLM-Image": "Flagship hybrid AR+Diffusion model by Z.ai. Leading open-source performance in complex text rendering and semantic image consistency."
+            "Qwen-Image": "A 20B MMDiT image foundation model that achieves significant advances in complex text rendering and precise image editing."
         }
     },
     "perplexity": {

--- a/model_pricing.json
+++ b/model_pricing.json
@@ -945,7 +945,8 @@
             "gemini-3-flash-preview": "google/gemini-3-flash-preview",
             "gemini-3-pro-image-preview": "google/gemini-3-pro-image-preview",
             "gemini-2.5-flash-image-preview": "google/gemini-2.5-flash-image-preview",
-            "gemini-2.0-flash-001": "google/gemini-2.0-flash-001"
+            "gemini-2.0-flash-001": "google/gemini-2.0-flash-001",
+            "gemini-3.1-pro-preview": "google/gemini-3.1-pro-preview"
         },
         "price": {
             "gemini-1.5-pro-latest": {

--- a/model_pricing.json
+++ b/model_pricing.json
@@ -48,7 +48,8 @@
             "gpt-5.2-2025-12-11",
             "gpt-5.2-pro",
             "gpt-5.2-pro-2025-12-11",
-            "gpt-5.3-codex"
+            "gpt-5.3-codex",
+            "gpt-5.4"
         ],
         "api_key": "OPENAI_API_KEY",
         "capabilities": {
@@ -246,6 +247,13 @@
                 "image",
                 "reasoning",
                 "search",
+                "mcp"
+            ],
+            "gpt-5.4": [
+                "reasoning",
+                "image",
+                "search",
+                "pdf",
                 "mcp"
             ]
         },
@@ -460,6 +468,10 @@
             "gpt-5.3-codex": {
                 "input": 1.75,
                 "output": 14
+            },
+            "gpt-5.4": {
+                "input": 2.50,
+                "output": 15
             }
         },
         "name": {
@@ -479,7 +491,8 @@
             "gpt-5.2": "GPT-5.2",
             "gpt-5.2-chat-latest": "GPT-5.2 Chat",
             "gpt-5.2-pro": "GPT-5.2 Pro",
-            "gpt-5.3-codex": "GPT-5.3 Codex"
+            "gpt-5.3-codex": "GPT-5.3 Codex",
+            "gpt-5.4": "GPT-5.4"
         },
         "availableForChatApp": {
             "gpt-4o-mini": "Free",
@@ -498,7 +511,8 @@
             "gpt-5.2": "Pro",
             "gpt-5.2-chat-latest": "Pro",
             "gpt-5.2-pro": "Pro",
-            "gpt-5.3-codex": "Pro"
+            "gpt-5.3-codex": "Pro",
+            "gpt-5.4": "Pro"
         },
         "descriptions": {
             "gpt-4o-mini": "Faster, less precise GPT-4o",
@@ -517,7 +531,8 @@
             "gpt-5.2": "OpenAI's Next-Gen Model",
             "gpt-5.2-chat-latest": "OpenAI's Next-Gen Chat Model",
             "gpt-5.2-pro": "OpenAI's most capable reasoning model",
-            "gpt-5.3-codex": "OpenAI's most capable agentic coding model to date."
+            "gpt-5.3-codex": "OpenAI's most capable agentic coding model to date.",
+            "gpt-5.4": "OpenAI's latest model with improved reasoning, image understanding, and search capabilities."
         },
         "alias": {
             "gpt-4o-2024-11-20": "gpt-4o",

--- a/model_pricing.json
+++ b/model_pricing.json
@@ -1441,11 +1441,11 @@
             "grok-4": [
                 "routing",
                 "image",
-                "reasoning",
+                "xSearch",
                 "search"
             ],
             "grok-4-fast": [
-                "reasoning",
+                "xSearch",
                 "search",
                 "image"
             ]

--- a/model_pricing.json
+++ b/model_pricing.json
@@ -49,7 +49,9 @@
             "gpt-5.2-pro",
             "gpt-5.2-pro-2025-12-11",
             "gpt-5.3-codex",
-            "gpt-5.4"
+            "gpt-5.4",
+            "gpt-5.4-mini",
+            "gpt-5.4-nano"
         ],
         "api_key": "OPENAI_API_KEY",
         "capabilities": {
@@ -257,6 +259,20 @@
                 "pdf",
                 "mcp",
                 "agent"
+            ],
+            "gpt-5.4-mini": [
+                "reasoning",
+                "image",
+                "search",
+                "pdf",
+                "mcp"
+            ],
+            "gpt-5.4-nano": [
+                "reasoning",
+                "image",
+                "search",
+                "pdf",
+                "mcp"
             ]
         },
         "openrouter_identifier": {
@@ -298,7 +314,9 @@
             "gpt-5.2-pro": "openai/gpt-5.2-pro",
             "gpt-5.2-pro-2025-12-11": "openai/gpt-5.2-pro",
             "gpt-5.3-codex": "openai/gpt-5.3-codex",
-            "gpt-5.4": "openai/gpt-5.4"
+            "gpt-5.4": "openai/gpt-5.4",
+            "gpt-5.4-mini": "openai/gpt-5.4-mini",
+            "gpt-5.4-nano": "openai/gpt-5.4-nano"
         },
         "price": {
             "gpt-3.5-turbo": {
@@ -476,6 +494,14 @@
             "gpt-5.4": {
                 "input": 2.50,
                 "output": 15
+            },
+            "gpt-5.4-mini": {
+                "input": 0.75,
+                "output": 4.50
+            },
+            "gpt-5.4-nano": {
+                "input": 0.20,
+                "output": 1.25
             }
         },
         "name": {
@@ -496,7 +522,9 @@
             "gpt-5.2-chat-latest": "GPT-5.2 Chat",
             "gpt-5.2-pro": "GPT-5.2 Pro",
             "gpt-5.3-codex": "GPT-5.3 Codex",
-            "gpt-5.4": "GPT-5.4"
+            "gpt-5.4": "GPT-5.4",
+            "gpt-5.4-mini": "GPT-5.4 Mini",
+            "gpt-5.4-nano": "GPT-5.4 Nano"
         },
         "availableForChatApp": {
             "gpt-4o-mini": "Free",
@@ -516,7 +544,9 @@
             "gpt-5.2-chat-latest": "Pro",
             "gpt-5.2-pro": "Pro",
             "gpt-5.3-codex": "Pro",
-            "gpt-5.4": "Pro"
+            "gpt-5.4": "Pro",
+            "gpt-5.4-mini": "Pro",
+            "gpt-5.4-nano": "Pro"
         },
         "descriptions": {
             "gpt-4o-mini": "Faster, less precise GPT-4o",
@@ -536,7 +566,9 @@
             "gpt-5.2-chat-latest": "OpenAI's Next-Gen Chat Model",
             "gpt-5.2-pro": "OpenAI's most capable reasoning model",
             "gpt-5.3-codex": "OpenAI's most capable agentic coding model to date.",
-            "gpt-5.4": "OpenAI's latest model with improved reasoning, image understanding, and search capabilities."
+            "gpt-5.4": "OpenAI's latest model with improved reasoning, image understanding, and search capabilities.",
+            "gpt-5.4-mini": "OpenAI's strongest mini model yet for coding, computer use, and subagents",
+            "gpt-5.4-nano": "OpenAI's cheapest GPT-5.4-class model for simple high-volume tasks"
         },
         "alias": {
             "gpt-4o-2024-11-20": "gpt-4o",
@@ -1050,7 +1082,10 @@
         },
         "alias": {
             "gemini-2.0-flash-001": "gemini-2.0-flash"
-        }
+        },
+        "requiresReasoning": [
+            "gemini-3.1-pro-preview"
+        ]
     },
     "cohere": {
         "icon": "https://svgl.app/library/cohere.svg",

--- a/model_pricing.json
+++ b/model_pricing.json
@@ -243,7 +243,6 @@
                 "mcp"
             ],
             "gpt-5.3-codex": [
-                "text",
                 "image",
                 "reasoning",
                 "search",
@@ -672,14 +671,12 @@
                 "reasoning"
             ],
             "claude-sonnet-4-6": [
-                "routing",
                 "image",
                 "pdf",
                 "computer-use",
                 "reasoning"
             ],
             "claude-opus-4-6": [
-                "routing",
                 "image",
                 "pdf",
                 "computer-use",
@@ -915,7 +912,6 @@
                 "search"
             ],
             "gemini-3.1-pro-preview": [
-                "text",
                 "pdf",
                 "image",
                 "search",

--- a/model_pricing.json
+++ b/model_pricing.json
@@ -939,7 +939,11 @@
                 "search",
                 "reasoning",
                 "agent"
-            ]
+            ],
+            "gemini-3.1-flash-image-preview": [
+                "image",
+                "image-gen"
+            ],
         },
         "openrouter_identifier": {
             "gemini-1.5-pro-latest": "google/gemini-pro-1.5",
@@ -948,7 +952,7 @@
             "gemini-2.5-flash": "google/gemini-2.5-flash",
             "gemini-2.5-pro": "google/gemini-2.5-pro",
             "gemini-3-pro-preview": "google/gemini-3-pro-preview",
-            "gemini-3-flash-preview": "google/gemini-3-flash-preview",
+            "gemini-3-flash": "google/gemini-3-flash-preview",
             "gemini-3-pro-image-preview": "google/gemini-3-pro-image-preview",
             "gemini-2.5-flash-image-preview": "google/gemini-2.5-flash-image-preview",
             "gemini-2.0-flash-001": "google/gemini-2.0-flash-001",
@@ -987,7 +991,7 @@
                 "input": 2,
                 "output": 12
             },
-            "gemini-3-flash-preview": {
+            "gemini-3-flash": {
                 "input": 0.5,
                 "output": 3
             },
@@ -998,6 +1002,10 @@
             "gemini-3.1-pro-preview": {
                 "input": 2,
                 "output": 12
+            },
+            "gemini-3.1-flash-image-preview": {
+                "input": 0.25,
+                "output": 3
             }
         },
         "name": {
@@ -1008,9 +1016,10 @@
             "gemini-2.5-flash-image-preview": "Nano Banana",
             "gemini-2.5-pro": "Gemini-2.5 Pro",
             "gemini-3-pro-preview": "Gemini-3 Pro",
-            "gemini-3-flash-preview": "Gemini-3 Flash",
+            "gemini-3-flash": "Gemini-3 Flash",
             "gemini-3-pro-image-preview": "Nano Banana Pro",
-            "gemini-3.1-pro-preview": "Gemini-3.1 Pro"
+            "gemini-3.1-pro-preview": "Gemini-3.1 Pro",
+            "gemini-3.1-flash-image-preview": "Nano Banana 2"
         },
         "availableForChatApp": {
             "gemini-1.5-pro-latest": "Pro",
@@ -1018,10 +1027,11 @@
             "gemini-2.5-flash": "Free",
             "gemini-2.5-pro": "Pro",
             "gemini-2.5-flash-image-preview": "Pro",
-            "gemini-3-flash-preview": "Free",
+            "gemini-3-flash": "Free",
             "gemini-3-pro-preview": "Pro",
             "gemini-3-pro-image-preview": "Pro",
-            "gemini-3.1-pro-preview": "Pro"
+            "gemini-3.1-pro-preview": "Pro",
+            "gemini-3.1-flash-image-preview": "Pro"
         },
         "descriptions": {
             "gemini-1.5-flash-latest": "Faster & less precise Gemini-1.5 Pro",
@@ -1031,9 +1041,10 @@
             "gemini-2.5-pro": "Google's newest experimental model",
             "gemini-2.5-flash-image-preview": "Google's newest img model (Nano Banana)",
             "gemini-3-pro-preview": "Google’s latest flagship Gemini model with advanced reasoning",
-            "gemini-3-flash-preview": "Fast and lightweight Gemini 3 model optimized for low latency",
-            "gemini-3-pro-image-preview": "Google's latest image model (Nano Banana 2)",
+            "gemini-3-flash": "Fast and lightweight Gemini 3 model optimized for low latency",
+            "gemini-3-pro-image-preview": "Google's latest Pro image model (Nano Banana Pro)",
             "gemini-3.1-pro-preview": "Google's latest and most advanced Gemini model with improved reasoning and creativity"
+            "gemini-3.1-flash-image-preview": "Google's latest fast image model (Nano Banana 2)"
         },
         "alias": {
             "gemini-2.0-flash-001": "gemini-2.0-flash"

--- a/model_pricing.json
+++ b/model_pricing.json
@@ -689,15 +689,13 @@
                 "image",
                 "pdf",
                 "computer-use",
-                "reasoning",
-                "routing"
+                "reasoning"
             ],
             "claude-opus-4-6": [
                 "image",
                 "pdf",
                 "computer-use",
-                "reasoning",
-                "routing"
+                "reasoning"
             ]
         },
         "openrouter_identifier": {

--- a/model_pricing.json
+++ b/model_pricing.json
@@ -716,7 +716,9 @@
             "claude-haiku-4-5-20251001": "anthropic/claude-haiku-4.5-20251001",
             "claude-sonnet-4-5-20250929": "anthropic/claude-sonnet-4.5-20250929",
             "claude-opus-4-5-20251101": "anthropic/claude-opus-4.5-20251101",
-            "claude-opus-4-1-20250805": "anthropic/claude-opus-4.1"
+            "claude-opus-4-1-20250805": "anthropic/claude-opus-4.1",
+            "claude-sonnet-4-6": "anthropic/claude-sonnet-4.6",
+            "claude-opus-4-6": "anthropic/claude-opus-4.6"
         },
         "price": {
             "claude-2.1": {
@@ -832,9 +834,7 @@
             "claude-sonnet-4-5-20250929": "claude-sonnet-4-5",
             "claude-opus-4-5-20251101": "claude-opus-4-5",
             "claude-haiku-4-5-20251001": "claude-haiku-4-5",
-            "claude-opus-4-1-20250805": "claude-opus-4-1",
-            "claude-sonnet-4-6": "claude-sonnet-4-6",
-            "claude-opus-4-6": "claude-opus-4-6"
+            "claude-opus-4-1-20250805": "claude-opus-4-1"
         },
         "descriptions": {
             "claude-3-haiku-20240307": "Anthropic's previous fastest model",


### PR DESCRIPTION
Added: 
Claude -> sonnet 4.6, opus 4.6
OpenAI GPT -> gpt-5.3-codex, gpt-5.4
Gemini -> gemini 3.1 pro

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added multiple new model variants across OpenAI (gpt-5.3-codex, gpt-5.4), Anthropic (claude-sonnet-4-6, claude-opus-4-6), and Google Gemini (flash, Pro, 3.1-series and image-preview variants); updated public names and image-preview variants.

* **Chores**
  * Updated pricing, availability flags, descriptions, aliases, and provider mappings; removed legacy GLM-Image entries and retained Qwen-Image as the primary image model; renamed several image-model entries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->