### PR TITLE
add model

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -5,28 +5,22 @@ on:
     types: [created]
   pull_request_review_comment:
     types: [created]
-  pull_request_review:
-    types: [submitted]
-  issues:
-    types: [opened, assigned]
 
 jobs:
   claude:
     if: |
       (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
-      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
-      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
-      (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
+      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude'))
     runs-on: ubuntu-latest
     permissions:
-      contents: write
-      pull-requests: write
-      issues: write
+      contents: read
+      pull-requests: read
+      issues: read
       id-token: write
       actions: read
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 1
 

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -11,7 +11,7 @@ jobs:
     if: |
       (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
       (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude'))
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-4vcpu-ubuntu-2404
     permissions:
       contents: read
       pull-requests: read

--- a/model_pricing.json
+++ b/model_pricing.json
@@ -949,6 +949,7 @@
             "gemini-3-flash",
             "gemini-3.1-pro-preview",
             "gemini-3.1-flash-lite-preview",
+            "gemini-3.5-flash",
             "gemini-2.5-flash-image-preview",
             "gemini-3-pro-image-preview",
             "gemini-3.1-flash-image-preview"
@@ -1012,8 +1013,13 @@
                 "agent-mode"
             ],
             "gemini-3.1-flash-lite-preview": [
-                "routing",
                 "image",
+                "search",
+                "reasoning"
+            ],
+            "gemini-3.5-flash": [
+                "image",
+                "pdf",
                 "search",
                 "reasoning"
             ],
@@ -1041,6 +1047,7 @@
             "gemini-3-flash": "google/gemini-3-flash-preview",
             "gemini-3.1-pro-preview": "google/gemini-3.1-pro-preview",
             "gemini-3.1-flash-lite-preview": "google/gemini-3.1-flash-lite-preview",
+            "gemini-3.5-flash": "google/gemini-3.5-flash",
             "gemini-2.5-flash-image-preview": "google/gemini-2.5-flash-image-preview",
             "gemini-3-pro-image-preview": "google/gemini-3-pro-image-preview",
             "gemini-3.1-flash-image-preview": "google/gemini-3.1-flash-image-preview"
@@ -1086,6 +1093,10 @@
                 "input": 0.25,
                 "output": 1.5
             },
+            "gemini-3.5-flash": {
+                "input": 1.5,
+                "output": 9
+            },
             "gemini-2.5-flash-image-preview": {
                 "input": 0.15,
                 "output": 0.6
@@ -1109,6 +1120,7 @@
             "gemini-3-flash": "Gemini-3 Flash",
             "gemini-3.1-pro-preview": "Gemini-3.1 Pro",
             "gemini-3.1-flash-lite-preview": "Gemini-3.1 Flash Lite",
+            "gemini-3.5-flash": "Gemini-3.5 Flash",
             "gemini-2.5-flash-image-preview": "Nano Banana",
             "gemini-3-pro-image-preview": "Nano Banana Pro",
             "gemini-3.1-flash-image-preview": "Nano Banana 2"
@@ -1122,6 +1134,7 @@
             "gemini-3-flash": "Free",
             "gemini-3.1-pro-preview": "Pro",
             "gemini-3.1-flash-lite-preview": "Free",
+            "gemini-3.5-flash": "Pro",
             "gemini-2.5-flash-image-preview": "Pro",
             "gemini-3-pro-image-preview": "Pro",
             "gemini-3.1-flash-image-preview": "Pro"
@@ -1136,6 +1149,7 @@
             "gemini-3-flash": "Fast and lightweight Gemini 3 model optimized for low latency",
             "gemini-3.1-pro-preview": "Google's latest and most advanced Gemini model with improved reasoning and creativity",
             "gemini-3.1-flash-lite-preview": "Google's lightweight Gemini 3.1 Flash model optimized for speed and efficiency",
+            "gemini-3.5-flash": "Google's flash-tier model optimized for coding and parallel agentic execution loops",
             "gemini-2.5-flash-image-preview": "Google's newest img model (Nano Banana)",
             "gemini-3-pro-image-preview": "Google's latest Pro image model (Nano Banana Pro)",
             "gemini-3.1-flash-image-preview": "Google's latest fast image model (Nano Banana 2)"
@@ -1649,7 +1663,8 @@
             "grok-3",
             "grok-3-mini",
             "grok-4",
-            "grok-4-fast"
+            "grok-4-fast",
+            "grok-4.3"
         ],
         "api_key": "XAI_API_KEY",
         "capabilities": {
@@ -1665,20 +1680,24 @@
             "grok-4": [
                 "routing",
                 "image",
-                "xSearch",
                 "search"
             ],
             "grok-4-fast": [
-                "xSearch",
                 "search",
                 "image"
+            ],
+            "grok-4.3": [
+                "image",
+                "search",
+                "reasoning"
             ]
         },
         "openrouter_identifier": {
             "grok-3": "x-ai/grok-3",
             "grok-3-mini": "x-ai/grok-3-mini",
             "grok-4": "x-ai/grok-4",
-            "grok-4-fast": "x-ai/grok-4-fast"
+            "grok-4-fast": "x-ai/grok-4-fast",
+            "grok-4.3": "x-ai/grok-4.3"
         },
         "price": {
             "grok-3": {
@@ -1696,25 +1715,31 @@
             "grok-4-fast": {
                 "input": 0.2,
                 "output": 0.5
+            },
+            "grok-4.3": {
+                "input": 1.25,
+                "output": 2.5
             }
         },
         "name": {
             "grok-3": "Grok 3",
             "grok-3-mini": "Grok 3 Mini",
             "grok-4": "Grok 4",
-            "grok-4-fast": "Grok 4 Fast"
+            "grok-4-fast": "Grok 4 Fast",
+            "grok-4.3": "Grok 4.3"
         },
         "availableForChatApp": {
             "grok-3": "Pro",
             "grok-3-mini": "Free",
-            "grok-4": "Pro",
-            "grok-4-fast": "Free"
+            "grok-4-fast": "Free",
+            "grok-4.3": "Pro"
         },
         "descriptions": {
             "grok-3": "Previous flagship model from xAI",
             "grok-3-mini": "Previous small model from xAI",
             "grok-4": "Latest reasoning model from xAI",
-            "grok-4-fast": "Low-latency, cost-efficient variant of Grok 4 optimized for speed"
+            "grok-4-fast": "Low-latency, cost-efficient variant of Grok 4 optimized for speed",
+            "grok-4.3": "xAI's flagship reasoning model with strong agentic tool calling and 1M context"
         }
     }
 }

--- a/model_pricing.json
+++ b/model_pricing.json
@@ -314,7 +314,7 @@
             "gpt-5.4": "openai/gpt-5.4",
             "gpt-5.4-mini": "openai/gpt-5.4-mini",
             "gpt-5.4-nano": "openai/gpt-5.4-nano",
-            "gpt-5.4-image-2": "openai/gpt-5.4-image-2",
+            "gpt-image-2": "openai/gpt-5.4-image-2",
             "gpt-5.5": "openai/gpt-5.5",
             "gpt-5.5-pro": "openai/gpt-5.5-pro"
         },

--- a/model_pricing.json
+++ b/model_pricing.json
@@ -12,14 +12,16 @@
             "gpt-4-0613",
             "gpt-4-turbo",
             "gpt-4-turbo-2024-04-09",
-            "gpt-4o",
-            "gpt-4o-2024-05-13",
-            "gpt-4o-2024-08-06",
-            "gpt-4o-mini",
-            "gpt-4o-mini-2024-07-18",
             "gpt-4-turbo-preview",
             "gpt-4-0125-preview",
             "gpt-4-1106-vision-preview",
+            "gpt-4o",
+            "gpt-4o-2024-05-13",
+            "gpt-4o-2024-08-06",
+            "gpt-4o-2024-11-20",
+            "gpt-4o-mini",
+            "gpt-4o-mini-2024-07-18",
+            "chatgpt-4o-latest",
             "gpt-4.1",
             "gpt-4.1-2025-04-14",
             "gpt-4.1-mini",
@@ -30,33 +32,31 @@
             "o1-preview-2024-09-12",
             "o1-mini",
             "o1-mini-2024-09-12",
-            "chatgpt-4o-latest",
             "gpt-5",
+            "gpt-5-2025-08-07",
             "gpt-5-mini",
+            "gpt-5-mini-2025-08-07",
             "gpt-5-nano",
-            "gpt-image-1",
-            "gpt-image-1.5",
-            "gpt-5-image",
-            "gpt-5-image-mini",
+            "gpt-5-nano-2025-08-07",
             "gpt-5.1",
+            "gpt-5.1-2025-11-13",
             "gpt-5.1-chat-latest",
             "gpt-5.2",
-            "gpt-5.2-chat-latest",
-            "gpt-4o-2024-11-20",
-            "gpt-5-2025-08-07",
-            "gpt-5-mini-2025-08-07",
-            "gpt-5-nano-2025-08-07",
-            "gpt-5.1-2025-11-13",
             "gpt-5.2-2025-12-11",
+            "gpt-5.2-chat-latest",
             "gpt-5.2-pro",
             "gpt-5.2-pro-2025-12-11",
             "gpt-5.3-codex",
             "gpt-5.4",
             "gpt-5.4-mini",
             "gpt-5.4-nano",
-            "gpt-image-2",
             "gpt-5.5",
-            "gpt-5.5-pro"
+            "gpt-5.5-pro",
+            "gpt-image-1",
+            "gpt-image-1.5",
+            "gpt-image-2",
+            "gpt-5-image",
+            "gpt-5-image-mini"
         ],
         "api_key": "OPENAI_API_KEY",
         "capabilities": {
@@ -69,6 +69,40 @@
                 "image"
             ],
             "gpt-4-1106-vision-preview": [
+                "routing",
+                "image"
+            ],
+            "gpt-4o": [
+                "routing",
+                "image",
+                "search"
+            ],
+            "gpt-4o-2024-05-13": [
+                "routing",
+                "image",
+                "search"
+            ],
+            "gpt-4o-2024-08-06": [
+                "routing",
+                "image",
+                "search"
+            ],
+            "gpt-4o-2024-11-20": [
+                "routing",
+                "image",
+                "search"
+            ],
+            "gpt-4o-mini": [
+                "routing",
+                "image",
+                "search"
+            ],
+            "gpt-4o-mini-2024-07-18": [
+                "routing",
+                "image",
+                "search"
+            ],
+            "chatgpt-4o-latest": [
                 "routing",
                 "image"
             ],
@@ -88,31 +122,6 @@
                 "search"
             ],
             "gpt-4.1-mini-2025-04-14": [
-                "routing",
-                "image",
-                "search"
-            ],
-            "gpt-4o": [
-                "routing",
-                "image",
-                "search"
-            ],
-            "gpt-4o-2024-05-13": [
-                "routing",
-                "image",
-                "search"
-            ],
-            "gpt-4o-2024-08-06": [
-                "routing",
-                "image",
-                "search"
-            ],
-            "gpt-4o-mini": [
-                "routing",
-                "image",
-                "search"
-            ],
-            "gpt-4o-mini-2024-07-18": [
                 "routing",
                 "image",
                 "search"
@@ -141,11 +150,13 @@
                 "file-search",
                 "code-interpreter"
             ],
-            "chatgpt-4o-latest": [
-                "routing",
-                "image"
-            ],
             "gpt-5": [
+                "reasoning",
+                "routing",
+                "image",
+                "search"
+            ],
+            "gpt-5-2025-08-07": [
                 "reasoning",
                 "routing",
                 "image",
@@ -157,20 +168,28 @@
                 "image",
                 "search"
             ],
+            "gpt-5-mini-2025-08-07": [
+                "reasoning",
+                "routing",
+                "image",
+                "search"
+            ],
             "gpt-5-nano": [
                 "routing",
                 "image",
                 "reasoning"
             ],
-            "gpt-image-1": [
+            "gpt-5-nano-2025-08-07": [
+                "routing",
                 "image",
-                "image-gen"
-            ],
-            "gpt-image-1.5": [
-                "image",
-                "image-gen"
+                "reasoning"
             ],
             "gpt-5.1": [
+                "reasoning",
+                "image",
+                "search"
+            ],
+            "gpt-5.1-2025-11-13": [
                 "reasoning",
                 "image",
                 "search"
@@ -185,39 +204,12 @@
                 "image",
                 "search"
             ],
-            "gpt-5.2-chat-latest": [
-                "reasoning",
-                "image",
-                "search"
-            ],
-            "gpt-4o-2024-11-20": [
-                "routing",
-                "image",
-                "search"
-            ],
-            "gpt-5-2025-08-07": [
-                "reasoning",
-                "routing",
-                "image",
-                "search"
-            ],
-            "gpt-5-mini-2025-08-07": [
-                "reasoning",
-                "routing",
-                "image",
-                "search"
-            ],
-            "gpt-5-nano-2025-08-07": [
-                "routing",
-                "image",
-                "reasoning"
-            ],
-            "gpt-5.1-2025-11-13": [
-                "reasoning",
-                "image",
-                "search"
-            ],
             "gpt-5.2-2025-12-11": [
+                "reasoning",
+                "image",
+                "search"
+            ],
+            "gpt-5.2-chat-latest": [
                 "reasoning",
                 "image",
                 "search"
@@ -257,10 +249,6 @@
                 "search",
                 "pdf"
             ],
-            "gpt-image-2": [
-                "image",
-                "image-gen"
-            ],
             "gpt-5.5": [
                 "reasoning",
                 "image",
@@ -272,6 +260,18 @@
                 "image",
                 "search",
                 "pdf"
+            ],
+            "gpt-image-1": [
+                "image",
+                "image-gen"
+            ],
+            "gpt-image-1.5": [
+                "image",
+                "image-gen"
+            ],
+            "gpt-image-2": [
+                "image",
+                "image-gen"
             ],
             "gpt-5-image": [
                 "image",
@@ -286,17 +286,14 @@
             "gpt-3.5-turbo": "openai/gpt-3.5-turbo",
             "gpt-4": "openai/gpt-4",
             "gpt-4-turbo": "openai/gpt-4-turbo",
+            "gpt-4-turbo-preview": "openai/gpt-4-turbo-preview",
+            "gpt-4-1106-vision-preview": "openai/gpt-4-1106-vision-preview",
             "gpt-4o": "openai/gpt-4o",
             "gpt-4o-2024-05-13": "openai/gpt-4o-2024-05-13",
             "gpt-4o-2024-08-06": "openai/gpt-4o-2024-08-06",
+            "gpt-4o-2024-11-20": "openai/gpt-4o",
             "gpt-4o-mini": "openai/gpt-4o-mini",
             "gpt-4o-mini-2024-07-18": "openai/gpt-4o-mini-2024-07-18",
-            "gpt-4-turbo-preview": "openai/gpt-4-turbo-preview",
-            "gpt-4-1106-vision-preview": "openai/gpt-4-1106-vision-preview",
-            "o1-preview": "openai/o1-preview",
-            "o1-preview-2024-09-12": "openai/o1-preview-2024-09-12",
-            "o1-mini": "openai/o1-mini",
-            "o1-mini-2024-09-12": "openai/o1-mini-2024-09-12",
             "chatgpt-4o-latest": "openai/chatgpt-4o-latest",
             "gpt-4.1": "openai/gpt-4.1",
             "gpt-4.1-2025-04-14": "openai/gpt-4.1-2025-04-14",
@@ -304,29 +301,32 @@
             "gpt-4.1-mini-2025-04-14": "openai/gpt-4.1-mini-2025-04-14",
             "gpt-4.1-nano": "openai/gpt-4.1-nano",
             "gpt-4.1-nano-2025-04-14": "openai/gpt-4.1-nano-2025-04-14",
+            "o1-preview": "openai/o1-preview",
+            "o1-preview-2024-09-12": "openai/o1-preview-2024-09-12",
+            "o1-mini": "openai/o1-mini",
+            "o1-mini-2024-09-12": "openai/o1-mini-2024-09-12",
             "gpt-5": "openai/gpt-5",
+            "gpt-5-2025-08-07": "openai/gpt-5",
             "gpt-5-mini": "openai/gpt-5-mini",
+            "gpt-5-mini-2025-08-07": "openai/gpt-5-mini",
             "gpt-5-nano": "openai/gpt-5-nano",
-            "gpt-image-1.5": "openai/gpt-image-1.5",
+            "gpt-5-nano-2025-08-07": "openai/gpt-5-nano",
             "gpt-5.1": "openai/gpt-5.1",
+            "gpt-5.1-2025-11-13": "openai/gpt-5.1",
             "gpt-5.1-chat-latest": "openai/gpt-5.1-chat",
             "gpt-5.2": "openai/gpt-5.2",
-            "gpt-5.2-chat-latest": "openai/gpt-5.2-chat",
-            "gpt-4o-2024-11-20": "openai/gpt-4o",
-            "gpt-5-2025-08-07": "openai/gpt-5",
-            "gpt-5-mini-2025-08-07": "openai/gpt-5-mini",
-            "gpt-5-nano-2025-08-07": "openai/gpt-5-nano",
-            "gpt-5.1-2025-11-13": "openai/gpt-5.1",
             "gpt-5.2-2025-12-11": "openai/gpt-5.2",
+            "gpt-5.2-chat-latest": "openai/gpt-5.2-chat",
             "gpt-5.2-pro": "openai/gpt-5.2-pro",
             "gpt-5.2-pro-2025-12-11": "openai/gpt-5.2-pro",
             "gpt-5.3-codex": "openai/gpt-5.3-codex",
             "gpt-5.4": "openai/gpt-5.4",
             "gpt-5.4-mini": "openai/gpt-5.4-mini",
             "gpt-5.4-nano": "openai/gpt-5.4-nano",
-            "gpt-image-2": "openai/gpt-5.4-image-2",
             "gpt-5.5": "openai/gpt-5.5",
-            "gpt-5.5-pro": "openai/gpt-5.5-pro"
+            "gpt-5.5-pro": "openai/gpt-5.5-pro",
+            "gpt-image-1.5": "openai/gpt-image-1.5",
+            "gpt-image-2": "openai/gpt-5.4-image-2",
             "gpt-5-image": "openai/gpt-5-image",
             "gpt-5-image-mini": "openai/gpt-5-image-mini"
         },
@@ -355,6 +355,18 @@
                 "input": 10,
                 "output": 30
             },
+            "gpt-4-turbo-preview": {
+                "input": 10,
+                "output": 30
+            },
+            "gpt-4-0125-preview": {
+                "input": 10,
+                "output": 30
+            },
+            "gpt-4-1106-vision-preview": {
+                "input": 10,
+                "output": 30
+            },
             "gpt-4o": {
                 "input": 2.5,
                 "output": 10
@@ -367,6 +379,10 @@
                 "input": 2.5,
                 "output": 10
             },
+            "gpt-4o-2024-11-20": {
+                "input": 2.5,
+                "output": 10
+            },
             "gpt-4o-mini": {
                 "input": 0.15,
                 "output": 0.6
@@ -375,17 +391,33 @@
                 "input": 0.15,
                 "output": 0.6
             },
-            "gpt-4-turbo-preview": {
-                "input": 10,
-                "output": 30
+            "chatgpt-4o-latest": {
+                "input": 5,
+                "output": 15
             },
-            "gpt-4-0125-preview": {
-                "input": 10,
-                "output": 30
+            "gpt-4.1": {
+                "input": 2,
+                "output": 8
             },
-            "gpt-4-1106-vision-preview": {
-                "input": 10,
-                "output": 30
+            "gpt-4.1-2025-04-14": {
+                "input": 2,
+                "output": 8
+            },
+            "gpt-4.1-mini": {
+                "input": 0.4,
+                "output": 1.6
+            },
+            "gpt-4.1-mini-2025-04-14": {
+                "input": 0.4,
+                "output": 1.6
+            },
+            "gpt-4.1-nano": {
+                "input": 0.1,
+                "output": 0.4
+            },
+            "gpt-4.1-nano-2025-04-14": {
+                "input": 0.1,
+                "output": 0.4
             },
             "o1-preview": {
                 "input": 15,
@@ -403,35 +435,11 @@
                 "input": 3,
                 "output": 12
             },
-            "chatgpt-4o-latest": {
-                "input": 5,
-                "output": 15
-            },
-            "gpt-4.1": {
-                "input": 2,
-                "output": 8
-            },
-            "gpt-4.1-mini": {
-                "input": 0.4,
-                "output": 1.6
-            },
-            "gpt-4.1-nano": {
-                "input": 0.1,
-                "output": 0.4
-            },
-            "gpt-4.1-2025-04-14": {
-                "input": 2,
-                "output": 8
-            },
-            "gpt-4.1-mini-2025-04-14": {
-                "input": 0.4,
-                "output": 1.6
-            },
-            "gpt-4.1-nano-2025-04-14": {
-                "input": 0.1,
-                "output": 0.4
-            },
             "gpt-5": {
+                "input": 1.25,
+                "output": 10
+            },
+            "gpt-5-2025-08-07": {
                 "input": 1.25,
                 "output": 10
             },
@@ -439,19 +447,23 @@
                 "input": 0.25,
                 "output": 2
             },
+            "gpt-5-mini-2025-08-07": {
+                "input": 0.25,
+                "output": 2
+            },
             "gpt-5-nano": {
                 "input": 0.05,
                 "output": 0.4
             },
-            "gpt-image-1": {
+            "gpt-5-nano-2025-08-07": {
                 "input": 0.05,
                 "output": 0.4
             },
-            "gpt-image-1.5": {
-                "input": 5,
+            "gpt-5.1": {
+                "input": 1.25,
                 "output": 10
             },
-            "gpt-5.1": {
+            "gpt-5.1-2025-11-13": {
                 "input": 1.25,
                 "output": 10
             },
@@ -463,31 +475,11 @@
                 "input": 1.75,
                 "output": 14
             },
-            "gpt-5.2-chat-latest": {
+            "gpt-5.2-2025-12-11": {
                 "input": 1.75,
                 "output": 14
             },
-            "gpt-4o-2024-11-20": {
-                "input": 2.5,
-                "output": 10
-            },
-            "gpt-5-2025-08-07": {
-                "input": 1.25,
-                "output": 10
-            },
-            "gpt-5-mini-2025-08-07": {
-                "input": 0.25,
-                "output": 2
-            },
-            "gpt-5-nano-2025-08-07": {
-                "input": 0.05,
-                "output": 0.4
-            },
-            "gpt-5.1-2025-11-13": {
-                "input": 1.25,
-                "output": 10
-            },
-            "gpt-5.2-2025-12-11": {
+            "gpt-5.2-chat-latest": {
                 "input": 1.75,
                 "output": 14
             },
@@ -515,10 +507,6 @@
                 "input": 0.2,
                 "output": 1.25
             },
-            "gpt-image-2": {
-                "input": 8,
-                "output": 15
-            },
             "gpt-5.5": {
                 "input": 5,
                 "output": 30
@@ -526,6 +514,19 @@
             "gpt-5.5-pro": {
                 "input": 30,
                 "output": 180
+            },
+            "gpt-image-1": {
+                "input": 0.05,
+                "output": 0.4
+            },
+            "gpt-image-1.5": {
+                "input": 5,
+                "output": 10
+            },
+            "gpt-image-2": {
+                "input": 8,
+                "output": 15
+            },
             "gpt-5-image": {
                 "input": 5,
                 "output": 10
@@ -536,17 +537,15 @@
             }
         },
         "name": {
-            "gpt-4o-mini": "GPT-4o Mini",
             "gpt-4o": "GPT-4o",
-            "o1-mini": "O1 Mini",
+            "gpt-4o-mini": "GPT-4o Mini",
             "chatgpt-4o-latest": "ChatGPT-4o",
-            "gpt-4.1-nano": "GPT-4.1 Nano",
             "gpt-4.1": "GPT-4.1",
+            "gpt-4.1-nano": "GPT-4.1 Nano",
+            "o1-mini": "O1 Mini",
             "gpt-5": "GPT-5",
             "gpt-5-mini": "GPT-5 Mini",
             "gpt-5-nano": "GPT-5 Nano",
-            "gpt-image-1": "GPT-Image 1",
-            "gpt-image-1.5": "GPT-Image 1.5",
             "gpt-5.1": "GPT-5.1",
             "gpt-5.1-chat-latest": "GPT-5.1 Chat",
             "gpt-5.2": "GPT-5.2",
@@ -556,19 +555,21 @@
             "gpt-5.4": "GPT-5.4",
             "gpt-5.4-mini": "GPT-5.4 Mini",
             "gpt-5.4-nano": "GPT-5.4 Nano",
-            "gpt-image-2": "GPT Image-2",
             "gpt-5.5": "GPT-5.5",
-            "gpt-5.5-pro": "GPT-5.5 Pro"
+            "gpt-5.5-pro": "GPT-5.5 Pro",
+            "gpt-image-1": "GPT-Image 1",
+            "gpt-image-1.5": "GPT-Image 1.5",
+            "gpt-image-2": "GPT Image-2",
             "gpt-5-image": "GPT-5 Image",
             "gpt-5-image-mini": "GPT-5 Image Mini"
         },
         "availableForChatApp": {
-            "gpt-4o-mini": "Free",
             "gpt-4o": "Pro",
-            "o1-mini": "Pro",
+            "gpt-4o-mini": "Free",
             "chatgpt-4o-latest": "Pro",
-            "gpt-4.1-nano": "Free",
             "gpt-4.1": "Pro",
+            "gpt-4.1-nano": "Free",
+            "o1-mini": "Pro",
             "gpt-5": "Pro",
             "gpt-5-mini": "Pro",
             "gpt-5-nano": "Free",
@@ -579,26 +580,24 @@
             "gpt-5.2-pro": "Pro",
             "gpt-5.3-codex": "Pro",
             "gpt-5.4": "Pro",
-            "gpt-image-2": "Pro",
-            "gpt-5.5": "Pro",
-            "gpt-5.5-pro": "Pro"
             "gpt-5.4-mini": "Free",
             "gpt-5.4-nano": "Free",
+            "gpt-5.5": "Pro",
+            "gpt-5.5-pro": "Pro",
+            "gpt-image-2": "Pro",
             "gpt-5-image": "Pro",
             "gpt-5-image-mini": "Pro"
         },
         "descriptions": {
-            "gpt-4o-mini": "Faster, less precise GPT-4o",
             "gpt-4o": "OpenAI's Flagship; versatile & intelligent",
-            "o1-mini": "OpenAI's previous small reasoning model",
+            "gpt-4o-mini": "Faster, less precise GPT-4o",
             "chatgpt-4o-latest": "ChatGPT Website version of 4o series",
-            "gpt-4.1-nano": "Fastest Model in GPT-4.1 series",
             "gpt-4.1": "OpenAI's Flagship Model",
+            "gpt-4.1-nano": "Fastest Model in GPT-4.1 series",
+            "o1-mini": "OpenAI's previous small reasoning model",
             "gpt-5": "OpenAI's Next-Gen Model",
             "gpt-5-mini": "OpenAI's Next-Gen Mini Model",
             "gpt-5-nano": "OpenAI's Next-Gen Nano Model",
-            "gpt-image-1": "OpenAI's Latest Image-Creating Model",
-            "gpt-image-1.5": "OpenAI’s latest image generation model with improved instruction following, higher fidelity, and faster performance",
             "gpt-5.1": "OpenAI's Next-Gen Model",
             "gpt-5.1-chat-latest": "OpenAI's Next-Gen Chat Model",
             "gpt-5.2": "OpenAI's Next-Gen Model",
@@ -608,9 +607,11 @@
             "gpt-5.4": "OpenAI's latest model with improved reasoning, image understanding, and search capabilities.",
             "gpt-5.4-mini": "OpenAI's strongest mini model yet for coding, computer use, and subagents",
             "gpt-5.4-nano": "OpenAI's cheapest GPT-5.4-class model for simple high-volume tasks",
-            "gpt-image-2": "OpenAI's frontier reasoning image generation model",
             "gpt-5.5": "OpenAI's frontier model for complex professional workloads with stronger reasoning and reliability",
-            "gpt-5.5-pro": "OpenAI's high-capability model optimized for deep reasoning on complex, high-stakes workloads"
+            "gpt-5.5-pro": "OpenAI's high-capability model optimized for deep reasoning on complex, high-stakes workloads",
+            "gpt-image-1": "OpenAI's Latest Image-Creating Model",
+            "gpt-image-1.5": "OpenAI\u2019s latest image generation model with improved instruction following, higher fidelity, and faster performance",
+            "gpt-image-2": "OpenAI's frontier reasoning image generation model",
             "gpt-5-image": "OpenAI's GPT-5 class image generation model with high fidelity and creative capabilities",
             "gpt-5-image-mini": "OpenAI's GPT-5 class image generation model optimized for speed and cost efficiency"
         },
@@ -645,13 +646,13 @@
             "claude-3-7-sonnet-latest",
             "claude-opus-4-20250514",
             "claude-opus-4-0",
+            "claude-opus-4-1",
+            "claude-opus-4-1-20250805",
             "claude-sonnet-4-20250514",
             "claude-sonnet-4-0",
-            "claude-opus-4-1",
             "claude-haiku-4-5-20251001",
             "claude-sonnet-4-5-20250929",
             "claude-opus-4-5-20251101",
-            "claude-opus-4-1-20250805",
             "claude-sonnet-4-6",
             "claude-opus-4-6"
         ],
@@ -691,13 +692,6 @@
                 "pdf",
                 "computer-use"
             ],
-            "claude-3-7-sonnet-latest": [
-                "routing",
-                "image",
-                "pdf",
-                "computer-use",
-                "reasoning"
-            ],
             "claude-3-7-sonnet-20250219": [
                 "routing",
                 "image",
@@ -705,14 +699,14 @@
                 "computer-use",
                 "reasoning"
             ],
-            "claude-opus-4-20250514": [
+            "claude-3-7-sonnet-latest": [
                 "routing",
                 "image",
                 "pdf",
                 "computer-use",
                 "reasoning"
             ],
-            "claude-sonnet-4-20250514": [
+            "claude-opus-4-20250514": [
                 "routing",
                 "image",
                 "pdf",
@@ -727,6 +721,20 @@
                 "reasoning"
             ],
             "claude-opus-4-1": [
+                "routing",
+                "image",
+                "pdf",
+                "computer-use",
+                "reasoning"
+            ],
+            "claude-opus-4-1-20250805": [
+                "routing",
+                "image",
+                "pdf",
+                "computer-use",
+                "reasoning"
+            ],
+            "claude-sonnet-4-20250514": [
                 "routing",
                 "image",
                 "pdf",
@@ -758,13 +766,6 @@
                 "computer-use",
                 "reasoning"
             ],
-            "claude-opus-4-1-20250805": [
-                "routing",
-                "image",
-                "pdf",
-                "computer-use",
-                "reasoning"
-            ],
             "claude-sonnet-4-6": [
                 "image",
                 "pdf",
@@ -785,20 +786,20 @@
             "claude-3-opus-20240229": "anthropic/claude-3-opus",
             "claude-3-sonnet-20240229": "anthropic/claude-3-sonnet",
             "claude-3-haiku-20240307": "anthropic/claude-3-haiku",
+            "claude-3-5-haiku-20241022": "anthropic/claude-3.5-haiku",
             "claude-3-5-sonnet-20240620": "anthropic/claude-3.5-sonnet-20240620",
             "claude-3-5-sonnet-latest": "anthropic/claude-3.5-sonnet",
-            "claude-3-5-haiku-20241022": "anthropic/claude-3.5-haiku",
-            "claude-3-7-sonnet-latest": "anthropic/claude-3.7-sonnet",
             "claude-3-7-sonnet-20250219": "anthropic/claude-3.7-sonnet",
+            "claude-3-7-sonnet-latest": "anthropic/claude-3.7-sonnet",
             "claude-opus-4-20250514": "anthropic/claude-opus-4",
-            "claude-sonnet-4-20250514": "anthropic/claude-sonnet-4",
             "claude-opus-4-0": "anthropic/claude-opus-4",
             "claude-opus-4-1": "anthropic/claude-opus-4.1",
+            "claude-opus-4-1-20250805": "anthropic/claude-opus-4.1",
+            "claude-sonnet-4-20250514": "anthropic/claude-sonnet-4",
             "claude-sonnet-4-0": "anthropic/claude-sonnet-4",
             "claude-haiku-4-5-20251001": "anthropic/claude-haiku-4.5-20251001",
             "claude-sonnet-4-5-20250929": "anthropic/claude-sonnet-4.5-20250929",
             "claude-opus-4-5-20251101": "anthropic/claude-opus-4.5-20251101",
-            "claude-opus-4-1-20250805": "anthropic/claude-opus-4.1",
             "claude-sonnet-4-6": "anthropic/claude-sonnet-4.6",
             "claude-opus-4-6": "anthropic/claude-opus-4.6"
         },
@@ -835,21 +836,17 @@
                 "input": 3,
                 "output": 15
             },
-            "claude-3-7-sonnet-latest": {
+            "claude-3-7-sonnet-20250219": {
                 "input": 3,
                 "output": 15
             },
-            "claude-3-7-sonnet-20250219": {
+            "claude-3-7-sonnet-latest": {
                 "input": 3,
                 "output": 15
             },
             "claude-opus-4-20250514": {
                 "input": 15,
                 "output": 75
-            },
-            "claude-sonnet-4-20250514": {
-                "input": 3,
-                "output": 15
             },
             "claude-opus-4-0": {
                 "input": 15,
@@ -858,6 +855,14 @@
             "claude-opus-4-1": {
                 "input": 15,
                 "output": 75
+            },
+            "claude-opus-4-1-20250805": {
+                "input": 15,
+                "output": 75
+            },
+            "claude-sonnet-4-20250514": {
+                "input": 3,
+                "output": 15
             },
             "claude-sonnet-4-0": {
                 "input": 3,
@@ -874,10 +879,6 @@
             "claude-opus-4-5-20251101": {
                 "input": 5,
                 "output": 25
-            },
-            "claude-opus-4-1-20250805": {
-                "input": 15,
-                "output": 75
             },
             "claude-sonnet-4-6": {
                 "input": 3,
@@ -913,10 +914,10 @@
         "alias": {
             "claude-3-5-haiku-20241022": "claude-3-5-haiku",
             "claude-3-5-sonnet-latest": "claude-3-5-sonnet",
-            "claude-sonnet-4-5-20250929": "claude-sonnet-4-5",
-            "claude-opus-4-5-20251101": "claude-opus-4-5",
+            "claude-opus-4-1-20250805": "claude-opus-4-1",
             "claude-haiku-4-5-20251001": "claude-haiku-4-5",
-            "claude-opus-4-1-20250805": "claude-opus-4-1"
+            "claude-sonnet-4-5-20250929": "claude-sonnet-4-5",
+            "claude-opus-4-5-20251101": "claude-opus-4-5"
         },
         "descriptions": {
             "claude-3-haiku-20240307": "Anthropic's previous fastest model",
@@ -925,7 +926,7 @@
             "claude-sonnet-4-20250514": "Anthropic's Flagship Model",
             "claude-haiku-4-5-20251001": "Fast and affordable Claude 4.5 model for lightweight tasks",
             "claude-sonnet-4-5-20250929": "Balanced Claude 4.5 model optimized for reasoning and reliability",
-            "claude-opus-4-5-20251101": "Anthropic’s most powerful Claude model for complex reasoning",
+            "claude-opus-4-5-20251101": "Anthropic\u2019s most powerful Claude model for complex reasoning",
             "claude-sonnet-4-6": "The best combination of speed and intelligence",
             "claude-opus-4-6": "The most intelligent model for building agents and coding"
         }
@@ -942,15 +943,15 @@
             "gemini-1.5-flash-latest",
             "gemini-2.0-flash",
             "gemini-2.0-flash-001",
-            "gemini-2.5-flash",
             "gemini-2.5-pro",
-            "gemini-2.5-flash-image-preview",
+            "gemini-2.5-flash",
             "gemini-3-pro-preview",
             "gemini-3-flash",
-            "gemini-3-pro-image-preview",
             "gemini-3.1-pro-preview",
-            "gemini-3.1-flash-image-preview",
-            "gemini-3.1-flash-lite-preview"
+            "gemini-3.1-flash-lite-preview",
+            "gemini-2.5-flash-image-preview",
+            "gemini-3-pro-image-preview",
+            "gemini-3.1-flash-image-preview"
         ],
         "api_key": "GOOGLE_GENERATIVE_AI_API_KEY",
         "capabilities": {
@@ -963,28 +964,17 @@
                 "image",
                 "search"
             ],
-            "gemini-2.0-flash-001": [
-                "routing",
-                "image",
-                "pdf",
-                "search"
-            ],
             "gemini-2.0-flash": [
                 "routing",
                 "image",
                 "pdf",
                 "search"
             ],
-            "gemini-2.5-flash": [
+            "gemini-2.0-flash-001": [
                 "routing",
                 "image",
                 "pdf",
-                "search",
-                "reasoning"
-            ],
-            "gemini-2.5-flash-image-preview": [
-                "image",
-                "image-gen"
+                "search"
             ],
             "gemini-2.5-pro": [
                 "routing",
@@ -993,9 +983,12 @@
                 "search",
                 "reasoning"
             ],
-            "gemini-3-pro-image-preview": [
+            "gemini-2.5-flash": [
+                "routing",
                 "image",
-                "image-gen"
+                "pdf",
+                "search",
+                "reasoning"
             ],
             "gemini-3-pro-preview": [
                 "routing",
@@ -1018,31 +1011,39 @@
                 "reasoning",
                 "agent-mode"
             ],
-            "gemini-3.1-flash-image-preview": [
-                "image",
-                "image-gen"
-            ],
             "gemini-3.1-flash-lite-preview": [
                 "routing",
                 "image",
                 "search",
                 "reasoning"
+            ],
+            "gemini-2.5-flash-image-preview": [
+                "image",
+                "image-gen"
+            ],
+            "gemini-3-pro-image-preview": [
+                "image",
+                "image-gen"
+            ],
+            "gemini-3.1-flash-image-preview": [
+                "image",
+                "image-gen"
             ]
         },
         "openrouter_identifier": {
             "gemini-1.5-pro-latest": "google/gemini-pro-1.5",
             "gemini-1.5-flash-latest": "google/gemini-flash-1.5",
             "gemini-2.0-flash": "google/gemini-2.0-flash",
-            "gemini-2.5-flash": "google/gemini-2.5-flash",
+            "gemini-2.0-flash-001": "google/gemini-2.0-flash-001",
             "gemini-2.5-pro": "google/gemini-2.5-pro",
+            "gemini-2.5-flash": "google/gemini-2.5-flash",
             "gemini-3-pro-preview": "google/gemini-3-pro-preview",
             "gemini-3-flash": "google/gemini-3-flash-preview",
-            "gemini-3-pro-image-preview": "google/gemini-3-pro-image-preview",
-            "gemini-2.5-flash-image-preview": "google/gemini-2.5-flash-image-preview",
-            "gemini-2.0-flash-001": "google/gemini-2.0-flash-001",
             "gemini-3.1-pro-preview": "google/gemini-3.1-pro-preview",
-            "gemini-3.1-flash-image-preview": "google/gemini-3.1-flash-image-preview",
-            "gemini-3.1-flash-lite-preview": "google/gemini-3.1-flash-lite-preview"
+            "gemini-3.1-flash-lite-preview": "google/gemini-3.1-flash-lite-preview",
+            "gemini-2.5-flash-image-preview": "google/gemini-2.5-flash-image-preview",
+            "gemini-3-pro-image-preview": "google/gemini-3-pro-image-preview",
+            "gemini-3.1-flash-image-preview": "google/gemini-3.1-flash-image-preview"
         },
         "price": {
             "gemini-1.5-pro-latest": {
@@ -1057,21 +1058,17 @@
                 "input": 0.15,
                 "output": 0.6
             },
-            "gemini-2.5-flash": {
+            "gemini-2.0-flash-001": {
                 "input": 0.15,
                 "output": 0.6
-            },
-            "gemini-2.5-flash-image-preview": {
-                "input": 0.15,
-                "output": 0.6
-            },
-            "gemini-3-pro-image-preview": {
-                "input": 2,
-                "output": 12
             },
             "gemini-2.5-pro": {
                 "input": 1.25,
                 "output": 10
+            },
+            "gemini-2.5-flash": {
+                "input": 0.15,
+                "output": 0.6
             },
             "gemini-3-pro-preview": {
                 "input": 2,
@@ -1081,63 +1078,67 @@
                 "input": 0.5,
                 "output": 3
             },
-            "gemini-2.0-flash-001": {
+            "gemini-3.1-pro-preview": {
+                "input": 2,
+                "output": 12
+            },
+            "gemini-3.1-flash-lite-preview": {
+                "input": 0.25,
+                "output": 1.5
+            },
+            "gemini-2.5-flash-image-preview": {
                 "input": 0.15,
                 "output": 0.6
             },
-            "gemini-3.1-pro-preview": {
+            "gemini-3-pro-image-preview": {
                 "input": 2,
                 "output": 12
             },
             "gemini-3.1-flash-image-preview": {
                 "input": 0.25,
                 "output": 3
-            },
-            "gemini-3.1-flash-lite-preview": {
-                "input": 0.25,
-                "output": 1.5
             }
         },
         "name": {
-            "gemini-1.5-flash-latest": "Gemini-1.5 Flash",
             "gemini-1.5-pro-latest": "Gemini-1.5 Pro",
+            "gemini-1.5-flash-latest": "Gemini-1.5 Flash",
             "gemini-2.0-flash": "Gemini-2.0 Flash",
-            "gemini-2.5-flash": "Gemini-2.5 Flash",
-            "gemini-2.5-flash-image-preview": "Nano Banana",
             "gemini-2.5-pro": "Gemini-2.5 Pro",
+            "gemini-2.5-flash": "Gemini-2.5 Flash",
             "gemini-3-pro-preview": "Gemini-3 Pro",
             "gemini-3-flash": "Gemini-3 Flash",
-            "gemini-3-pro-image-preview": "Nano Banana Pro",
             "gemini-3.1-pro-preview": "Gemini-3.1 Pro",
-            "gemini-3.1-flash-image-preview": "Nano Banana 2",
-            "gemini-3.1-flash-lite-preview": "Gemini-3.1 Flash Lite"
+            "gemini-3.1-flash-lite-preview": "Gemini-3.1 Flash Lite",
+            "gemini-2.5-flash-image-preview": "Nano Banana",
+            "gemini-3-pro-image-preview": "Nano Banana Pro",
+            "gemini-3.1-flash-image-preview": "Nano Banana 2"
         },
         "availableForChatApp": {
             "gemini-1.5-pro-latest": "Pro",
             "gemini-2.0-flash": "Free",
-            "gemini-2.5-flash": "Free",
             "gemini-2.5-pro": "Pro",
-            "gemini-2.5-flash-image-preview": "Pro",
-            "gemini-3-flash": "Free",
+            "gemini-2.5-flash": "Free",
             "gemini-3-pro-preview": "Pro",
-            "gemini-3-pro-image-preview": "Pro",
+            "gemini-3-flash": "Free",
             "gemini-3.1-pro-preview": "Pro",
-            "gemini-3.1-flash-image-preview": "Pro",
-            "gemini-3.1-flash-lite-preview": "Free"
+            "gemini-3.1-flash-lite-preview": "Free",
+            "gemini-2.5-flash-image-preview": "Pro",
+            "gemini-3-pro-image-preview": "Pro",
+            "gemini-3.1-flash-image-preview": "Pro"
         },
         "descriptions": {
-            "gemini-1.5-flash-latest": "Faster & less precise Gemini-1.5 Pro",
             "gemini-1.5-pro-latest": "Google's previous flagship model",
+            "gemini-1.5-flash-latest": "Faster & less precise Gemini-1.5 Pro",
             "gemini-2.0-flash": "Google's latest stable model",
-            "gemini-2.5-flash": "Google's latest fastest model",
             "gemini-2.5-pro": "Google's newest experimental model",
-            "gemini-2.5-flash-image-preview": "Google's newest img model (Nano Banana)",
-            "gemini-3-pro-preview": "Google’s latest flagship Gemini model with advanced reasoning",
+            "gemini-2.5-flash": "Google's latest fastest model",
+            "gemini-3-pro-preview": "Google\u2019s latest flagship Gemini model with advanced reasoning",
             "gemini-3-flash": "Fast and lightweight Gemini 3 model optimized for low latency",
-            "gemini-3-pro-image-preview": "Google's latest Pro image model (Nano Banana Pro)",
             "gemini-3.1-pro-preview": "Google's latest and most advanced Gemini model with improved reasoning and creativity",
-            "gemini-3.1-flash-image-preview": "Google's latest fast image model (Nano Banana 2)",
-            "gemini-3.1-flash-lite-preview": "Google's lightweight Gemini 3.1 Flash model optimized for speed and efficiency"
+            "gemini-3.1-flash-lite-preview": "Google's lightweight Gemini 3.1 Flash model optimized for speed and efficiency",
+            "gemini-2.5-flash-image-preview": "Google's newest img model (Nano Banana)",
+            "gemini-3-pro-image-preview": "Google's latest Pro image model (Nano Banana Pro)",
+            "gemini-3.1-flash-image-preview": "Google's latest fast image model (Nano Banana 2)"
         },
         "alias": {
             "gemini-2.0-flash-001": "gemini-2.0-flash"
@@ -1182,9 +1183,9 @@
             "mistral-medium-latest",
             "mistral-small-latest",
             "open-mistral-7b",
+            "open-mistral-nemo",
             "open-mixtral-8x7b",
             "open-mixtral-8x22b",
-            "open-mistral-nemo",
             "codestral-latest"
         ],
         "api_key": "MISTRAL_API_KEY",
@@ -1199,9 +1200,9 @@
             "mistral-medium-latest": "mistralai/mistral-medium",
             "mistral-small-latest": "mistralai/mistral-small",
             "open-mistral-7b": "mistralai/mistral-7b-instruct",
+            "open-mistral-nemo": "mistralai/mistral-nemo",
             "open-mixtral-8x7b": "mistralai/mixtral-8x7b",
-            "open-mixtral-8x22b": "mistralai/mixtral-8x22b-instruct",
-            "open-mistral-nemo": "mistralai/mistral-nemo"
+            "open-mixtral-8x22b": "mistralai/mixtral-8x22b-instruct"
         },
         "price": {
             "mistral-large-latest": {
@@ -1228,6 +1229,10 @@
                 "input": 0.25,
                 "output": 0.25
             },
+            "open-mistral-nemo": {
+                "input": 0.15,
+                "output": 0.15
+            },
             "open-mixtral-8x7b": {
                 "input": 0.7,
                 "output": 0.7
@@ -1235,10 +1240,6 @@
             "open-mixtral-8x22b": {
                 "input": 2,
                 "output": 6
-            },
-            "open-mistral-nemo": {
-                "input": 0.15,
-                "output": 0.15
             },
             "codestral-latest": {
                 "input": 1,
@@ -1265,15 +1266,15 @@
             "Mistral-7B-Instruct-v0.2",
             "Mixtral-8x7B-Instruct-v0.1",
             "Mixtral-8x22B-Instruct-v0.1",
-            "Llama-3-70b-chat-hf",
             "Llama-3-8b-chat-hf",
-            "Qwen2-72B-Instruct",
+            "Llama-3-70b-chat-hf",
             "Meta-Llama-3.1-8B-Instruct-Turbo",
             "Meta-Llama-3.1-70B-Instruct-Turbo",
             "Meta-Llama-3.1-405B-Instruct-Turbo",
+            "Qwen2-72B-Instruct",
+            "Qwen3-30B-A3B",
             "DeepSeek-R1",
             "Kimi-K2-Thinking",
-            "Qwen3-30B-A3B",
             "Qwen-Image"
         ],
         "api_key": "TOGETHER_AI_API_KEY",
@@ -1281,18 +1282,23 @@
             "Mistral-7B-Instruct-v0.2": "mistralai",
             "Mixtral-8x7B-Instruct-v0.1": "mistralai",
             "Mixtral-8x22B-Instruct-v0.1": "mistralai",
-            "Llama-3-70b-chat-hf": "meta-llama",
             "Llama-3-8b-chat-hf": "meta-llama",
-            "Qwen2-72B-Instruct": "Qwen",
+            "Llama-3-70b-chat-hf": "meta-llama",
             "Meta-Llama-3.1-8B-Instruct-Turbo": "meta-llama",
             "Meta-Llama-3.1-70B-Instruct-Turbo": "meta-llama",
             "Meta-Llama-3.1-405B-Instruct-Turbo": "meta-llama",
+            "Qwen2-72B-Instruct": "Qwen",
+            "Qwen3-30B-A3B": "Qwen",
             "DeepSeek-R1": "deepseek-ai",
             "Kimi-K2-Thinking": "moonshotai",
-            "Qwen3-30B-A3B": "Qwen",
             "Qwen-Image": "Qwen"
         },
         "capabilities": {
+            "Qwen3-30B-A3B": [
+                "routing",
+                "reasoning",
+                "search"
+            ],
             "DeepSeek-R1": [
                 "routing",
                 "reasoning"
@@ -1302,28 +1308,23 @@
                 "routing",
                 "agentic"
             ],
-            "Qwen3-30B-A3B": [
-                "routing",
-                "reasoning",
-                "search"
-            ],
             "Qwen-Image": [
                 "image-gen"
             ]
         },
         "openrouter_identifier": {
-            "Llama-3-70b-chat-hf": "meta-llama/llama-3-70b-instruct",
-            "Llama-3-8b-chat-hf": "meta-llama/llama-3-8b-instruct",
-            "Qwen2-72B-Instruct": "qwen/qwen-2-72b-instruct",
             "Mistral-7B-Instruct-v0.2": "mistralai/mistral-7b-instruct",
             "Mixtral-8x7B-Instruct-v0.1": "mistralai/mixtral-8x7b",
             "Mixtral-8x22B-Instruct-v0.1": "mistralai/mixtral-8x22b-instruct",
+            "Llama-3-8b-chat-hf": "meta-llama/llama-3-8b-instruct",
+            "Llama-3-70b-chat-hf": "meta-llama/llama-3-70b-instruct",
             "Meta-Llama-3.1-8B-Instruct-Turbo": "meta-llama/llama-3.1-8b-instruct",
             "Meta-Llama-3.1-70B-Instruct-Turbo": "meta-llama/llama-3.1-70b-instruct",
             "Meta-Llama-3.1-405B-Instruct-Turbo": "meta-llama/llama-3.1-405b-instruct",
+            "Qwen2-72B-Instruct": "qwen/qwen-2-72b-instruct",
+            "Qwen3-30B-A3B": "Qwen/qwen3-30B-A3B",
             "DeepSeek-R1": "deepseek/deepseek-r1",
             "Kimi-K2-Thinking": "moonshotai/kimi-k2-thinking",
-            "Qwen3-30B-A3B": "Qwen/qwen3-30B-A3B",
             "Qwen-Image": "Qwen/Qwen-Image"
         },
         "price": {
@@ -1339,17 +1340,13 @@
                 "input": 0.6,
                 "output": 0.6
             },
-            "Llama-3-70b-chat-hf": {
-                "input": 0.7,
-                "output": 0.7
-            },
             "Llama-3-8b-chat-hf": {
                 "input": 0.2,
                 "output": 0.2
             },
-            "Qwen2-72B-Instruct": {
-                "input": 0.9,
-                "output": 0.9
+            "Llama-3-70b-chat-hf": {
+                "input": 0.7,
+                "output": 0.7
             },
             "Meta-Llama-3.1-8B-Instruct-Turbo": {
                 "input": 0.18,
@@ -1363,6 +1360,14 @@
                 "input": 5,
                 "output": 15
             },
+            "Qwen2-72B-Instruct": {
+                "input": 0.9,
+                "output": 0.9
+            },
+            "Qwen3-30B-A3B": {
+                "input": 0.3,
+                "output": 1.2
+            },
             "DeepSeek-R1": {
                 "input": 3,
                 "output": 7
@@ -1371,10 +1376,6 @@
                 "input": 0.15,
                 "output": 2.5
             },
-            "Qwen3-30B-A3B": {
-                "input": 0.3,
-                "output": 1.2
-            },
             "Qwen-Image": {
                 "input": 0,
                 "output": 75
@@ -1382,21 +1383,21 @@
         },
         "name": {
             "Meta-Llama-3.1-70B-Instruct-Turbo": "Llama-3.1 70B",
+            "Qwen3-30B-A3B": "Qwen-3-30B",
             "DeepSeek-R1": "DeepSeek-R1",
             "Kimi-K2-Thinking": "Kimi-K2-Thinking",
-            "Qwen3-30B-A3B": "Qwen-3-30B",
             "Qwen-Image": "Qwen-Image"
         },
         "availableForChatApp": {
             "Meta-Llama-3.1-70B-Instruct-Turbo": "Free",
-            "Kimi-K2-Thinking": "Pro",
-            "Qwen3-30B-A3B": "Pro"
+            "Qwen3-30B-A3B": "Pro",
+            "Kimi-K2-Thinking": "Pro"
         },
         "descriptions": {
             "Meta-Llama-3.1-70B-Instruct-Turbo": "Meta's 70B flagship model",
+            "Qwen3-30B-A3B": "Qwen3 hybrid reasoning model with large context and multilingual support",
             "DeepSeek-R1": "DeepSeek's Reasoning Model",
             "Kimi-K2-Thinking": "Open-source agentic reasoning model with deep multi-step planning and tool use",
-            "Qwen3-30B-A3B": "Qwen3 hybrid reasoning model with large context and multilingual support",
             "Qwen-Image": "A 20B MMDiT image foundation model that achieves significant advances in complex text rendering and precise image editing."
         }
     },
@@ -1569,23 +1570,23 @@
         "models": [
             "mistral-7b-instruct-v0.2",
             "mixtral-8x7b-instruct-v0.1",
-            "meta-llama-3-70b-instruct",
             "meta-llama-3-8b-instruct",
+            "meta-llama-3-70b-instruct",
             "meta-llama-3.1-405b-instruct"
         ],
         "api_key": "REPLICATE_API_TOKEN",
         "model_prefix": {
             "mistral-7b-instruct-v0.2": "mistralai",
             "mixtral-8x7b-instruct-v0.1": "mistralai",
-            "meta-llama-3-70b-instruct": "meta",
             "meta-llama-3-8b-instruct": "meta",
+            "meta-llama-3-70b-instruct": "meta",
             "meta-llama-3.1-405b-instruct": "meta"
         },
         "openrouter_identifier": {
             "mistral-7b-instruct-v0.2": "mistralai/mistral-7b-instruct",
             "mixtral-8x7b-instruct-v0.1": "mistralai/mixtral-8x7b",
-            "meta-llama-3-70b-instruct": "meta-llama/llama-3-70b-instruct",
             "meta-llama-3-8b-instruct": "meta-llama/llama-3-8b-instruct",
+            "meta-llama-3-70b-instruct": "meta-llama/llama-3-70b-instruct",
             "meta-llama-3.1-405b-instruct": "meta-llama/llama-3.1-405b-instruct"
         },
         "price": {
@@ -1597,13 +1598,13 @@
                 "input": 0.6,
                 "output": 0.6
             },
-            "meta-llama-3-70b-instruct": {
-                "input": 0.65,
-                "output": 2.75
-            },
             "meta-llama-3-8b-instruct": {
                 "input": 0.05,
                 "output": 0.25
+            },
+            "meta-llama-3-70b-instruct": {
+                "input": 0.65,
+                "output": 2.75
             },
             "meta-llama-3.1-405b-instruct": {
                 "input": 9.5,
@@ -1698,21 +1699,21 @@
             }
         },
         "name": {
-            "grok-4": "Grok 4",
             "grok-3": "Grok 3",
             "grok-3-mini": "Grok 3 Mini",
+            "grok-4": "Grok 4",
             "grok-4-fast": "Grok 4 Fast"
         },
         "availableForChatApp": {
-            "grok-4": "Pro",
             "grok-3": "Pro",
             "grok-3-mini": "Free",
+            "grok-4": "Pro",
             "grok-4-fast": "Free"
         },
         "descriptions": {
-            "grok-4": "Latest reasoning model from xAI",
             "grok-3": "Previous flagship model from xAI",
             "grok-3-mini": "Previous small model from xAI",
+            "grok-4": "Latest reasoning model from xAI",
             "grok-4-fast": "Low-latency, cost-efficient variant of Grok 4 optimized for speed"
         }
     }

--- a/model_pricing.json
+++ b/model_pricing.json
@@ -262,12 +262,14 @@
             "gpt-5.5": [
                 "reasoning",
                 "image",
-                "search"
+                "search",
+                "pdf"
             ],
             "gpt-5.5-pro": [
                 "reasoning",
                 "image",
-                "search"
+                "search",
+                "pdf"
             ]
         },
         "openrouter_identifier": {
@@ -1233,7 +1235,8 @@
             "Meta-Llama-3.1-405B-Instruct-Turbo",
             "DeepSeek-R1",
             "Kimi-K2-Thinking",
-            "Qwen3-30B-A3B"
+            "Qwen3-30B-A3B",
+            "Qwen-Image"
         ],
         "api_key": "TOGETHER_AI_API_KEY",
         "model_prefix": {
@@ -1248,7 +1251,8 @@
             "Meta-Llama-3.1-405B-Instruct-Turbo": "meta-llama",
             "DeepSeek-R1": "deepseek-ai",
             "Kimi-K2-Thinking": "moonshotai",
-            "Qwen3-30B-A3B": "Qwen"
+            "Qwen3-30B-A3B": "Qwen",
+            "Qwen-Image": "Qwen"
         },
         "capabilities": {
             "DeepSeek-R1": [
@@ -1264,6 +1268,9 @@
                 "routing",
                 "reasoning",
                 "search"
+            ],
+            "Qwen-Image": [
+                "image-gen"
             ]
         },
         "openrouter_identifier": {
@@ -1278,7 +1285,8 @@
             "Meta-Llama-3.1-405B-Instruct-Turbo": "meta-llama/llama-3.1-405b-instruct",
             "DeepSeek-R1": "deepseek/deepseek-r1",
             "Kimi-K2-Thinking": "moonshotai/kimi-k2-thinking",
-            "Qwen3-30B-A3B": "Qwen/qwen3-30B-A3B"
+            "Qwen3-30B-A3B": "Qwen/qwen3-30B-A3B",
+            "Qwen-Image": "Qwen/Qwen-Image"
         },
         "price": {
             "Mistral-7B-Instruct-v0.2": {
@@ -1328,13 +1336,18 @@
             "Qwen3-30B-A3B": {
                 "input": 0.3,
                 "output": 1.2
+            },
+            "Qwen-Image": {
+                "input": 0,
+                "output": 75
             }
         },
         "name": {
             "Meta-Llama-3.1-70B-Instruct-Turbo": "Llama-3.1 70B",
             "DeepSeek-R1": "DeepSeek-R1",
             "Kimi-K2-Thinking": "Kimi-K2-Thinking",
-            "Qwen3-30B-A3B": "Qwen-3-30B"
+            "Qwen3-30B-A3B": "Qwen-3-30B",
+            "Qwen-Image": "Qwen-Image"
         },
         "availableForChatApp": {
             "Meta-Llama-3.1-70B-Instruct-Turbo": "Free",
@@ -1345,7 +1358,8 @@
             "Meta-Llama-3.1-70B-Instruct-Turbo": "Meta's 70B flagship model",
             "DeepSeek-R1": "DeepSeek's Reasoning Model",
             "Kimi-K2-Thinking": "Open-source agentic reasoning model with deep multi-step planning and tool use",
-            "Qwen3-30B-A3B": "Qwen3 hybrid reasoning model with large context and multilingual support"
+            "Qwen3-30B-A3B": "Qwen3 hybrid reasoning model with large context and multilingual support",
+            "Qwen-Image": "A 20B MMDiT image foundation model that achieves significant advances in complex text rendering and precise image editing."
         }
     },
     "moonshotai": {
@@ -1360,10 +1374,9 @@
         "api_key": "MOONSHOT_API_KEY",
         "capabilities": {
             "Kimi-K2.6": [
-                "routing",
                 "image",
-                "reasoning",
-                "agent-mode"
+                "pdf",
+                "reasoning"
             ]
         },
         "openrouter_identifier": {
@@ -1398,14 +1411,10 @@
         "api_key": "DEEPSEEK_API_KEY",
         "capabilities": {
             "DeepSeek-V4-Flash": [
-                "routing",
-                "reasoning",
-                "agent-mode"
+                "reasoning"
             ],
             "DeepSeek-V4-Pro": [
-                "routing",
-                "reasoning",
-                "agent-mode"
+                "reasoning"
             ]
         },
         "openrouter_identifier": {
@@ -1438,7 +1447,9 @@
     "xiaomi": {
         "icon": "https://svgl.app/library/xiaomi.svg",
         "sources": [
-            "https://openrouter.ai/xiaomi"
+            "https://openrouter.ai/xiaomi",
+            "https://vercel.com/ai-gateway/models/mimo-v2-pro",
+            "https://vercel.com/ai-gateway/models/mimo-v2-flash"
         ],
         "models": [
             "MiMo-V2.5",
@@ -1447,16 +1458,12 @@
         "api_key": "XIAOMI_API_KEY",
         "capabilities": {
             "MiMo-V2.5": [
-                "routing",
                 "image",
-                "reasoning",
-                "agent-mode"
+                "reasoning"
             ],
             "MiMo-V2.5-Pro": [
-                "routing",
                 "image",
-                "reasoning",
-                "agent-mode"
+                "reasoning"
             ]
         },
         "openrouter_identifier": {
@@ -1482,8 +1489,8 @@
             "MiMo-V2.5-Pro": "Pro"
         },
         "descriptions": {
-            "MiMo-V2.5": "Xiaomi's omnimodal model with agentic capabilities at roughly half the cost of MiMo Pro",
-            "MiMo-V2.5-Pro": "Xiaomi's flagship model for agentic tasks, software engineering, and long-horizon workflows"
+            "MiMo-V2.5": "Xiaomi's omnimodal model (image + video) with 1M context, delivering Pro-level agentic performance at roughly half the cost",
+            "MiMo-V2.5-Pro": "Xiaomi's flagship model with 1M context, optimized for agentic tasks, complex software engineering, and long-horizon workflows"
         }
     },
     "perplexity": {

--- a/model_pricing.json
+++ b/model_pricing.json
@@ -503,7 +503,7 @@
                 "input": 0.20,
                 "output": 1.25
             },
-            "gpt-5.4-image-2": {
+            "gpt-image-2": {
                 "input": 8,
                 "output": 15
             },

--- a/model_pricing.json
+++ b/model_pricing.json
@@ -587,7 +587,7 @@
             "gpt-5.4": "OpenAI's latest model with improved reasoning, image understanding, and search capabilities.",
             "gpt-5.4-mini": "OpenAI's strongest mini model yet for coding, computer use, and subagents",
             "gpt-5.4-nano": "OpenAI's cheapest GPT-5.4-class model for simple high-volume tasks",
-            "gpt-5.4-image-2": "OpenAI's GPT-5.4 combined with GPT Image-2 for multimodal reasoning and image generation",
+            "gpt-5.4-image-2": "OpenAI's frontier reasoning image generation model",
             "gpt-5.5": "OpenAI's frontier model for complex professional workloads with stronger reasoning and reliability",
             "gpt-5.5-pro": "OpenAI's high-capability model optimized for deep reasoning on complex, high-stakes workloads"
         },

--- a/model_pricing.json
+++ b/model_pricing.json
@@ -1363,7 +1363,7 @@
         }
     },
     "moonshotai": {
-        "icon": "https://svgl.app/library/moonshot.svg",
+        "icon": "https://svgl.app/library/kimi-icon.svg",
         "sources": [
             "https://openrouter.ai/moonshotai",
             "https://platform.moonshot.ai/docs/pricing"

--- a/model_pricing.json
+++ b/model_pricing.json
@@ -255,7 +255,7 @@
                 "search",
                 "pdf"
             ],
-            "gpt-5.4-image-2": [
+            "gpt-image-2": [
                 "image",
                 "image-gen"
             ],

--- a/model_pricing.json
+++ b/model_pricing.json
@@ -51,7 +51,10 @@
             "gpt-5.3-codex",
             "gpt-5.4",
             "gpt-5.4-mini",
-            "gpt-5.4-nano"
+            "gpt-5.4-nano",
+            "gpt-5.4-image-2",
+            "gpt-5.5",
+            "gpt-5.5-pro"
         ],
         "api_key": "OPENAI_API_KEY",
         "capabilities": {
@@ -116,28 +119,24 @@
                 "routing",
                 "image",
                 "file-search",
-                "mcp",
                 "code-interpreter"
             ],
             "gpt-4.1-nano-2025-04-14": [
                 "routing",
                 "image",
                 "file-search",
-                "mcp",
                 "code-interpreter"
             ],
             "o1-mini": [
                 "routing",
                 "image",
                 "file-search",
-                "mcp",
                 "code-interpreter"
             ],
             "o1-mini-2024-09-12": [
                 "routing",
                 "image",
                 "file-search",
-                "mcp",
                 "code-interpreter"
             ],
             "chatgpt-4o-latest": [
@@ -148,21 +147,18 @@
                 "reasoning",
                 "routing",
                 "image",
-                "search",
-                "mcp"
+                "search"
             ],
             "gpt-5-mini": [
                 "reasoning",
                 "routing",
                 "image",
-                "search",
-                "mcp"
+                "search"
             ],
             "gpt-5-nano": [
                 "routing",
                 "image",
-                "reasoning",
-                "mcp"
+                "reasoning"
             ],
             "gpt-image-1": [
                 "image",
@@ -175,26 +171,22 @@
             "gpt-5.1": [
                 "reasoning",
                 "image",
-                "search",
-                "mcp"
+                "search"
             ],
             "gpt-5.1-chat-latest": [
                 "reasoning",
                 "image",
-                "search",
-                "mcp"
+                "search"
             ],
             "gpt-5.2": [
                 "reasoning",
                 "image",
-                "search",
-                "mcp"
+                "search"
             ],
             "gpt-5.2-chat-latest": [
                 "reasoning",
                 "image",
-                "search",
-                "mcp"
+                "search"
             ],
             "gpt-4o-2024-11-20": [
                 "routing",
@@ -205,74 +197,77 @@
                 "reasoning",
                 "routing",
                 "image",
-                "search",
-                "mcp"
+                "search"
             ],
             "gpt-5-mini-2025-08-07": [
                 "reasoning",
                 "routing",
                 "image",
-                "search",
-                "mcp"
+                "search"
             ],
             "gpt-5-nano-2025-08-07": [
                 "routing",
                 "image",
-                "reasoning",
-                "mcp"
+                "reasoning"
             ],
             "gpt-5.1-2025-11-13": [
                 "reasoning",
                 "image",
-                "search",
-                "mcp"
+                "search"
             ],
             "gpt-5.2-2025-12-11": [
                 "reasoning",
                 "image",
-                "search",
-                "mcp"
+                "search"
             ],
             "gpt-5.2-pro": [
                 "reasoning",
                 "image",
-                "search",
-                "mcp"
+                "search"
             ],
             "gpt-5.2-pro-2025-12-11": [
                 "reasoning",
                 "image",
-                "search",
-                "mcp"
+                "search"
             ],
             "gpt-5.3-codex": [
                 "image",
                 "reasoning",
                 "search",
-                "mcp",
-                "agent"
+                "agent-mode"
             ],
             "gpt-5.4": [
                 "reasoning",
                 "image",
                 "search",
                 "pdf",
-                "mcp",
-                "agent"
+                "agent-mode"
             ],
             "gpt-5.4-mini": [
                 "reasoning",
                 "image",
                 "search",
-                "pdf",
-                "mcp"
+                "pdf"
             ],
             "gpt-5.4-nano": [
                 "reasoning",
                 "image",
                 "search",
-                "pdf",
-                "mcp"
+                "pdf"
+            ],
+            "gpt-5.4-image-2": [
+                "image",
+                "image-gen"
+            ],
+            "gpt-5.5": [
+                "reasoning",
+                "image",
+                "search"
+            ],
+            "gpt-5.5-pro": [
+                "reasoning",
+                "image",
+                "search"
             ]
         },
         "openrouter_identifier": {
@@ -316,7 +311,10 @@
             "gpt-5.3-codex": "openai/gpt-5.3-codex",
             "gpt-5.4": "openai/gpt-5.4",
             "gpt-5.4-mini": "openai/gpt-5.4-mini",
-            "gpt-5.4-nano": "openai/gpt-5.4-nano"
+            "gpt-5.4-nano": "openai/gpt-5.4-nano",
+            "gpt-5.4-image-2": "openai/gpt-5.4-image-2",
+            "gpt-5.5": "openai/gpt-5.5",
+            "gpt-5.5-pro": "openai/gpt-5.5-pro"
         },
         "price": {
             "gpt-3.5-turbo": {
@@ -502,6 +500,18 @@
             "gpt-5.4-nano": {
                 "input": 0.20,
                 "output": 1.25
+            },
+            "gpt-5.4-image-2": {
+                "input": 8,
+                "output": 15
+            },
+            "gpt-5.5": {
+                "input": 5,
+                "output": 30
+            },
+            "gpt-5.5-pro": {
+                "input": 30,
+                "output": 180
             }
         },
         "name": {
@@ -524,7 +534,10 @@
             "gpt-5.3-codex": "GPT-5.3 Codex",
             "gpt-5.4": "GPT-5.4",
             "gpt-5.4-mini": "GPT-5.4 Mini",
-            "gpt-5.4-nano": "GPT-5.4 Nano"
+            "gpt-5.4-nano": "GPT-5.4 Nano",
+            "gpt-5.4-image-2": "GPT Image-2",
+            "gpt-5.5": "GPT-5.5",
+            "gpt-5.5-pro": "GPT-5.5 Pro"
         },
         "availableForChatApp": {
             "gpt-4o-mini": "Free",
@@ -546,7 +559,10 @@
             "gpt-5.3-codex": "Pro",
             "gpt-5.4": "Pro",
             "gpt-5.4-mini": "Pro",
-            "gpt-5.4-nano": "Pro"
+            "gpt-5.4-nano": "Pro",
+            "gpt-5.4-image-2": "Pro",
+            "gpt-5.5": "Pro",
+            "gpt-5.5-pro": "Pro"
         },
         "descriptions": {
             "gpt-4o-mini": "Faster, less precise GPT-4o",
@@ -568,7 +584,10 @@
             "gpt-5.3-codex": "OpenAI's most capable agentic coding model to date.",
             "gpt-5.4": "OpenAI's latest model with improved reasoning, image understanding, and search capabilities.",
             "gpt-5.4-mini": "OpenAI's strongest mini model yet for coding, computer use, and subagents",
-            "gpt-5.4-nano": "OpenAI's cheapest GPT-5.4-class model for simple high-volume tasks"
+            "gpt-5.4-nano": "OpenAI's cheapest GPT-5.4-class model for simple high-volume tasks",
+            "gpt-5.4-image-2": "OpenAI's GPT-5.4 combined with GPT Image-2 for multimodal reasoning and image generation",
+            "gpt-5.5": "OpenAI's frontier model for complex professional workloads with stronger reasoning and reliability",
+            "gpt-5.5-pro": "OpenAI's high-capability model optimized for deep reasoning on complex, high-stakes workloads"
         },
         "alias": {
             "gpt-4o-2024-11-20": "gpt-4o",
@@ -726,14 +745,14 @@
                 "pdf",
                 "computer-use",
                 "reasoning",
-                "agent"
+                "agent-mode"
             ],
             "claude-opus-4-6": [
                 "image",
                 "pdf",
                 "computer-use",
                 "reasoning",
-                "agent"
+                "agent-mode"
             ]
         },
         "openrouter_identifier": {
@@ -964,14 +983,14 @@
                 "image",
                 "search",
                 "reasoning",
-                "agent"
+                "agent-mode"
             ],
             "gemini-3.1-pro-preview": [
                 "pdf",
                 "image",
                 "search",
                 "reasoning",
-                "agent"
+                "agent-mode"
             ],
             "gemini-3.1-flash-image-preview": [
                 "image",
@@ -1214,8 +1233,7 @@
             "Meta-Llama-3.1-405B-Instruct-Turbo",
             "DeepSeek-R1",
             "Kimi-K2-Thinking",
-            "Qwen3-30B-A3B",
-            "Qwen-Image"
+            "Qwen3-30B-A3B"
         ],
         "api_key": "TOGETHER_AI_API_KEY",
         "model_prefix": {
@@ -1230,8 +1248,7 @@
             "Meta-Llama-3.1-405B-Instruct-Turbo": "meta-llama",
             "DeepSeek-R1": "deepseek-ai",
             "Kimi-K2-Thinking": "moonshotai",
-            "Qwen3-30B-A3B": "Qwen",
-            "Qwen-Image": "Qwen"
+            "Qwen3-30B-A3B": "Qwen"
         },
         "capabilities": {
             "DeepSeek-R1": [
@@ -1247,9 +1264,6 @@
                 "routing",
                 "reasoning",
                 "search"
-            ],
-            "Qwen-Image": [
-                "image-gen"
             ]
         },
         "openrouter_identifier": {
@@ -1264,8 +1278,7 @@
             "Meta-Llama-3.1-405B-Instruct-Turbo": "meta-llama/llama-3.1-405b-instruct",
             "DeepSeek-R1": "deepseek/deepseek-r1",
             "Kimi-K2-Thinking": "moonshotai/kimi-k2-thinking",
-            "Qwen3-30B-A3B": "Qwen/qwen3-30B-A3B",
-            "Qwen-Image": "Qwen/Qwen-Image"
+            "Qwen3-30B-A3B": "Qwen/qwen3-30B-A3B"
         },
         "price": {
             "Mistral-7B-Instruct-v0.2": {
@@ -1315,32 +1328,162 @@
             "Qwen3-30B-A3B": {
                 "input": 0.3,
                 "output": 1.2
-            },
-            "Qwen-Image": {
-                "input": 0,
-                "output": 75
             }
         },
         "name": {
             "Meta-Llama-3.1-70B-Instruct-Turbo": "Llama-3.1 70B",
             "DeepSeek-R1": "DeepSeek-R1",
             "Kimi-K2-Thinking": "Kimi-K2-Thinking",
-            "Qwen3-30B-A3B": "Qwen-3-30B",
-            "Qwen-Image": "Qwen-Image"
+            "Qwen3-30B-A3B": "Qwen-3-30B"
         },
         "availableForChatApp": {
             "Meta-Llama-3.1-70B-Instruct-Turbo": "Free",
-            "DeepSeek-R1": "Pro",
             "Kimi-K2-Thinking": "Pro",
-            "Qwen3-30B-A3B": "Pro",
-            "Qwen-Image": "Pro"
+            "Qwen3-30B-A3B": "Pro"
         },
         "descriptions": {
             "Meta-Llama-3.1-70B-Instruct-Turbo": "Meta's 70B flagship model",
             "DeepSeek-R1": "DeepSeek's Reasoning Model",
             "Kimi-K2-Thinking": "Open-source agentic reasoning model with deep multi-step planning and tool use",
-            "Qwen3-30B-A3B": "Qwen3 hybrid reasoning model with large context and multilingual support",
-            "Qwen-Image": "A 20B MMDiT image foundation model that achieves significant advances in complex text rendering and precise image editing."
+            "Qwen3-30B-A3B": "Qwen3 hybrid reasoning model with large context and multilingual support"
+        }
+    },
+    "moonshotai": {
+        "icon": "https://svgl.app/library/moonshot.svg",
+        "sources": [
+            "https://openrouter.ai/moonshotai",
+            "https://platform.moonshot.ai/docs/pricing"
+        ],
+        "models": [
+            "Kimi-K2.6"
+        ],
+        "api_key": "MOONSHOT_API_KEY",
+        "capabilities": {
+            "Kimi-K2.6": [
+                "routing",
+                "image",
+                "reasoning",
+                "agent-mode"
+            ]
+        },
+        "openrouter_identifier": {
+            "Kimi-K2.6": "moonshotai/kimi-k2.6"
+        },
+        "price": {
+            "Kimi-K2.6": {
+                "input": 0.7448,
+                "output": 4.655
+            }
+        },
+        "name": {
+            "Kimi-K2.6": "Kimi K2.6"
+        },
+        "availableForChatApp": {
+            "Kimi-K2.6": "Pro"
+        },
+        "descriptions": {
+            "Kimi-K2.6": "Moonshot's multimodal model for long-horizon coding, UI/UX generation from visuals, and multi-agent orchestration"
+        }
+    },
+    "deepseek": {
+        "icon": "https://svgl.app/library/deepseek.svg",
+        "sources": [
+            "https://openrouter.ai/provider/deepseek",
+            "https://api-docs.deepseek.com/quick_start/pricing"
+        ],
+        "models": [
+            "DeepSeek-V4-Flash",
+            "DeepSeek-V4-Pro"
+        ],
+        "api_key": "DEEPSEEK_API_KEY",
+        "capabilities": {
+            "DeepSeek-V4-Flash": [
+                "routing",
+                "reasoning",
+                "agent-mode"
+            ],
+            "DeepSeek-V4-Pro": [
+                "routing",
+                "reasoning",
+                "agent-mode"
+            ]
+        },
+        "openrouter_identifier": {
+            "DeepSeek-V4-Flash": "deepseek/deepseek-v4-flash",
+            "DeepSeek-V4-Pro": "deepseek/deepseek-v4-pro"
+        },
+        "price": {
+            "DeepSeek-V4-Flash": {
+                "input": 0.14,
+                "output": 0.28
+            },
+            "DeepSeek-V4-Pro": {
+                "input": 0.435,
+                "output": 0.87
+            }
+        },
+        "name": {
+            "DeepSeek-V4-Flash": "DeepSeek-V4 Flash",
+            "DeepSeek-V4-Pro": "DeepSeek-V4 Pro"
+        },
+        "availableForChatApp": {
+            "DeepSeek-V4-Flash": "Pro",
+            "DeepSeek-V4-Pro": "Pro"
+        },
+        "descriptions": {
+            "DeepSeek-V4-Flash": "DeepSeek's efficient MoE model (284B/13B active) with 1M context optimized for fast reasoning and coding",
+            "DeepSeek-V4-Pro": "DeepSeek's flagship 1.6T-parameter MoE for complex reasoning, full-codebase analysis, and agentic workflows"
+        }
+    },
+    "xiaomi": {
+        "icon": "https://svgl.app/library/xiaomi.svg",
+        "sources": [
+            "https://openrouter.ai/xiaomi"
+        ],
+        "models": [
+            "MiMo-V2.5",
+            "MiMo-V2.5-Pro"
+        ],
+        "api_key": "XIAOMI_API_KEY",
+        "capabilities": {
+            "MiMo-V2.5": [
+                "routing",
+                "image",
+                "reasoning",
+                "agent-mode"
+            ],
+            "MiMo-V2.5-Pro": [
+                "routing",
+                "image",
+                "reasoning",
+                "agent-mode"
+            ]
+        },
+        "openrouter_identifier": {
+            "MiMo-V2.5": "xiaomi/mimo-v2.5",
+            "MiMo-V2.5-Pro": "xiaomi/mimo-v2.5-pro"
+        },
+        "price": {
+            "MiMo-V2.5": {
+                "input": 0.4,
+                "output": 2
+            },
+            "MiMo-V2.5-Pro": {
+                "input": 1,
+                "output": 3
+            }
+        },
+        "name": {
+            "MiMo-V2.5": "MiMo-V2.5",
+            "MiMo-V2.5-Pro": "MiMo-V2.5 Pro"
+        },
+        "availableForChatApp": {
+            "MiMo-V2.5": "Pro",
+            "MiMo-V2.5-Pro": "Pro"
+        },
+        "descriptions": {
+            "MiMo-V2.5": "Xiaomi's omnimodal model with agentic capabilities at roughly half the cost of MiMo Pro",
+            "MiMo-V2.5-Pro": "Xiaomi's flagship model for agentic tasks, software engineering, and long-horizon workflows"
         }
     },
     "perplexity": {

--- a/model_pricing.json
+++ b/model_pricing.json
@@ -1445,7 +1445,7 @@
         }
     },
     "xiaomi": {
-        "icon": "https://svgl.app/library/xiaomi.svg",
+        "icon": "https://upload.wikimedia.org/wikipedia/commons/a/ae/Xiaomi_logo_%282021-%29.svg",
         "sources": [
             "https://openrouter.ai/xiaomi",
             "https://vercel.com/ai-gateway/models/mimo-v2-pro",

--- a/model_pricing.json
+++ b/model_pricing.json
@@ -537,7 +537,7 @@
             "gpt-5.4": "GPT-5.4",
             "gpt-5.4-mini": "GPT-5.4 Mini",
             "gpt-5.4-nano": "GPT-5.4 Nano",
-            "gpt-5.4-image-2": "GPT Image-2",
+            "gpt-image-2": "GPT Image-2",
             "gpt-5.5": "GPT-5.5",
             "gpt-5.5-pro": "GPT-5.5 Pro"
         },
@@ -562,7 +562,7 @@
             "gpt-5.4": "Pro",
             "gpt-5.4-mini": "Pro",
             "gpt-5.4-nano": "Pro",
-            "gpt-5.4-image-2": "Pro",
+            "gpt-image-2": "Pro",
             "gpt-5.5": "Pro",
             "gpt-5.5-pro": "Pro"
         },
@@ -587,7 +587,7 @@
             "gpt-5.4": "OpenAI's latest model with improved reasoning, image understanding, and search capabilities.",
             "gpt-5.4-mini": "OpenAI's strongest mini model yet for coding, computer use, and subagents",
             "gpt-5.4-nano": "OpenAI's cheapest GPT-5.4-class model for simple high-volume tasks",
-            "gpt-5.4-image-2": "OpenAI's frontier reasoning image generation model",
+            "gpt-image-2": "OpenAI's frontier reasoning image generation model",
             "gpt-5.5": "OpenAI's frontier model for complex professional workloads with stronger reasoning and reliability",
             "gpt-5.5-pro": "OpenAI's high-capability model optimized for deep reasoning on complex, high-stakes workloads"
         },

--- a/model_pricing.json
+++ b/model_pricing.json
@@ -52,7 +52,7 @@
             "gpt-5.4",
             "gpt-5.4-mini",
             "gpt-5.4-nano",
-            "gpt-5.4-image-2",
+            "gpt-image-2",
             "gpt-5.5",
             "gpt-5.5-pro"
         ],


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * New AI model providers available: Moonshot (Kimi-K2.6), DeepSeek (V4-Flash and V4-Pro), Xiaomi (MiMo-V2.5 and MiMo-V2.5-Pro)
  * New OpenAI models added: gpt-image-2, gpt-5.5, and gpt-5.5-pro

* **Updates**
  * Capability updates across multiple models
  * Removed DeepSeek-R1, Qwen3-30B-A3B, and Qwen-Image from chat app availability
<!-- end of auto-generated comment: release notes by coderabbit.ai -->