### PR TITLE
chore: deprecate prior-generation models + add release_date field

### DIFF
--- a/model_pricing.json
+++ b/model_pricing.json
@@ -564,21 +564,6 @@
             "gpt-5-image-mini": "GPT-5 Image Mini"
         },
         "availableForChatApp": {
-            "gpt-4o": "Pro",
-            "gpt-4o-mini": "Free",
-            "chatgpt-4o-latest": "Pro",
-            "gpt-4.1": "Pro",
-            "gpt-4.1-nano": "Free",
-            "o1-mini": "Pro",
-            "gpt-5": "Pro",
-            "gpt-5-mini": "Pro",
-            "gpt-5-nano": "Free",
-            "gpt-5.1": "Pro",
-            "gpt-5.1-chat-latest": "Pro",
-            "gpt-5.2": "Pro",
-            "gpt-5.2-chat-latest": "Pro",
-            "gpt-5.2-pro": "Pro",
-            "gpt-5.3-codex": "Pro",
             "gpt-5.4": "Pro",
             "gpt-5.4-mini": "Free",
             "gpt-5.4-nano": "Free",
@@ -631,8 +616,31 @@
             "o1-mini",
             "o1-mini-2024-09-12",
             "chatgpt-4o-latest",
-            "gpt-image-1"
-        ]
+            "gpt-image-1",
+            "gpt-4o",
+            "gpt-4o-mini",
+            "gpt-4.1",
+            "gpt-4.1-nano",
+            "gpt-5",
+            "gpt-5-mini",
+            "gpt-5-nano",
+            "gpt-5.1",
+            "gpt-5.1-chat-latest",
+            "gpt-5.2",
+            "gpt-5.2-chat-latest",
+            "gpt-5.2-pro",
+            "gpt-5.3-codex"
+        ],
+        "release_date": {
+            "gpt-5.4": "2026-03-05",
+            "gpt-5.4-mini": "2026-03-17",
+            "gpt-5.4-nano": "2026-03-17",
+            "gpt-5.5": "2026-04-24",
+            "gpt-5.5-pro": "2026-04-24",
+            "gpt-image-2": "2026-04-22",
+            "gpt-5-image": "2025-10-14",
+            "gpt-5-image-mini": "2025-10-16"
+        }
     },
     "anthropic": {
         "icon": "https://svgl.app/library/claude-ai-icon.svg",
@@ -794,14 +802,14 @@
             "claude-opus-4-7": [
                 "image",
                 "pdf",
-                "reasoning", 
-                 "agent-mode"
+                "reasoning",
+                "agent-mode"
             ],
             "claude-opus-4-8": [
                 "image",
                 "pdf",
                 "reasoning",
-                 "agent-mode"
+                "agent-mode"
             ]
         },
         "openrouter_identifier": {
@@ -820,9 +828,9 @@
             "claude-opus-4-1-20250805": "anthropic/claude-opus-4.1",
             "claude-sonnet-4-20250514": "anthropic/claude-sonnet-4",
             "claude-sonnet-4-0": "anthropic/claude-sonnet-4",
-            "claude-haiku-4-5-20251001": "anthropic/claude-haiku-4.5-20251001",
-            "claude-sonnet-4-5-20250929": "anthropic/claude-sonnet-4.5-20250929",
-            "claude-opus-4-5-20251101": "anthropic/claude-opus-4.5-20251101",
+            "claude-haiku-4-5-20251001": "anthropic/claude-haiku-4.5",
+            "claude-sonnet-4-5-20250929": "anthropic/claude-sonnet-4.5",
+            "claude-opus-4-5-20251101": "anthropic/claude-opus-4.5",
             "claude-sonnet-4-6": "anthropic/claude-sonnet-4.6",
             "claude-opus-4-6": "anthropic/claude-opus-4.6",
             "claude-opus-4-7": "anthropic/claude-opus-4.7",
@@ -936,10 +944,6 @@
             "claude-opus-4-8": "Claude-4.8 Opus"
         },
         "availableForChatApp": {
-            "claude-3-haiku-20240307": "Free",
-            "claude-3-5-haiku-20241022": "Pro",
-            "claude-3-5-sonnet-latest": "Pro",
-            "claude-sonnet-4-20250514": "Pro",
             "claude-haiku-4-5-20251001": "Pro",
             "claude-sonnet-4-5-20250929": "Pro",
             "claude-opus-4-5-20251101": "Pro",
@@ -968,6 +972,21 @@
             "claude-opus-4-6": "The most intelligent model for building agents and coding",
             "claude-opus-4-7": "Highly autonomous Claude model for long-horizon agentic work and coding",
             "claude-opus-4-8": "Anthropic's most capable model for complex reasoning and autonomous agents"
+        },
+        "deprecated": [
+            "claude-3-haiku-20240307",
+            "claude-3-5-haiku-20241022",
+            "claude-3-5-sonnet-latest",
+            "claude-sonnet-4-20250514"
+        ],
+        "release_date": {
+            "claude-haiku-4-5-20251001": "2025-10-15",
+            "claude-sonnet-4-5-20250929": "2025-09-29",
+            "claude-opus-4-5-20251101": "2025-11-25",
+            "claude-sonnet-4-6": "2026-02-17",
+            "claude-opus-4-6": "2026-02-04",
+            "claude-opus-4-7": "2026-04-16",
+            "claude-opus-4-8": "2026-05-27"
         }
     },
     "google": {
@@ -1094,7 +1113,7 @@
             "gemini-3.1-pro-preview": "google/gemini-3.1-pro-preview",
             "gemini-3.1-flash-lite-preview": "google/gemini-3.1-flash-lite-preview",
             "gemini-3.5-flash": "google/gemini-3.5-flash",
-            "gemini-2.5-flash-image-preview": "google/gemini-2.5-flash-image-preview",
+            "gemini-2.5-flash-image-preview": "google/gemini-2.5-flash-image",
             "gemini-3-pro-image-preview": "google/gemini-3-pro-image-preview",
             "gemini-3.1-flash-image-preview": "google/gemini-3.1-flash-image-preview"
         },
@@ -1172,10 +1191,6 @@
             "gemini-3.1-flash-image-preview": "Nano Banana 2"
         },
         "availableForChatApp": {
-            "gemini-1.5-pro-latest": "Pro",
-            "gemini-2.0-flash": "Free",
-            "gemini-2.5-pro": "Pro",
-            "gemini-2.5-flash": "Free",
             "gemini-3-pro-preview": "Pro",
             "gemini-3-flash": "Free",
             "gemini-3.1-pro-preview": "Pro",
@@ -1205,7 +1220,22 @@
         },
         "requiresReasoning": [
             "gemini-3.1-pro-preview"
-        ]
+        ],
+        "deprecated": [
+            "gemini-1.5-pro-latest",
+            "gemini-2.0-flash",
+            "gemini-2.5-pro",
+            "gemini-2.5-flash"
+        ],
+        "release_date": {
+            "gemini-3-flash": "2025-12-17",
+            "gemini-3.1-pro-preview": "2026-02-19",
+            "gemini-3.1-flash-lite-preview": "2026-03-03",
+            "gemini-3.5-flash": "2026-05-19",
+            "gemini-2.5-flash-image-preview": "2025-10-08",
+            "gemini-3-pro-image-preview": "2025-11-20",
+            "gemini-3.1-flash-image-preview": "2026-02-26"
+        }
     },
     "cohere": {
         "icon": "https://svgl.app/library/cohere.svg",
@@ -1309,15 +1339,14 @@
         "name": {
             "mistral-large-latest": "Mistral Large-2"
         },
-        "availableForChatApp": {
-            "mistral-large-latest": "Pro"
-        },
+        "availableForChatApp": {},
         "description": {
             "mistral-large-latest": "Mistral's latest flagship model"
         },
         "deprecated": [
             "open-mistral-7b",
-            "open-mixtral-8x7b"
+            "open-mixtral-8x7b",
+            "mistral-large-latest"
         ]
     },
     "togetherai": {
@@ -1386,7 +1415,7 @@
             "Meta-Llama-3.1-70B-Instruct-Turbo": "meta-llama/llama-3.1-70b-instruct",
             "Meta-Llama-3.1-405B-Instruct-Turbo": "meta-llama/llama-3.1-405b-instruct",
             "Qwen2-72B-Instruct": "qwen/qwen-2-72b-instruct",
-            "Qwen3-30B-A3B": "Qwen/qwen3-30B-A3B",
+            "Qwen3-30B-A3B": "qwen/qwen3-30b-a3b",
             "DeepSeek-R1": "deepseek/deepseek-r1",
             "Kimi-K2-Thinking": "moonshotai/kimi-k2-thinking",
             "Qwen-Image": "Qwen/Qwen-Image"
@@ -1452,18 +1481,19 @@
             "Kimi-K2-Thinking": "Kimi-K2-Thinking",
             "Qwen-Image": "Qwen-Image"
         },
-        "availableForChatApp": {
-            "Meta-Llama-3.1-70B-Instruct-Turbo": "Free",
-            "Qwen3-30B-A3B": "Pro",
-            "Kimi-K2-Thinking": "Pro"
-        },
+        "availableForChatApp": {},
         "descriptions": {
             "Meta-Llama-3.1-70B-Instruct-Turbo": "Meta's 70B flagship model",
             "Qwen3-30B-A3B": "Qwen3 hybrid reasoning model with large context and multilingual support",
             "DeepSeek-R1": "DeepSeek's Reasoning Model",
             "Kimi-K2-Thinking": "Open-source agentic reasoning model with deep multi-step planning and tool use",
             "Qwen-Image": "A 20B MMDiT image foundation model that achieves significant advances in complex text rendering and precise image editing."
-        }
+        },
+        "deprecated": [
+            "Meta-Llama-3.1-70B-Instruct-Turbo",
+            "Qwen3-30B-A3B",
+            "Kimi-K2-Thinking"
+        ]
     },
     "moonshotai": {
         "icon": "https://svgl.app/library/kimi-icon.svg",
@@ -1499,6 +1529,9 @@
         },
         "descriptions": {
             "Kimi-K2.6": "Moonshot's multimodal model for long-horizon coding, UI/UX generation from visuals, and multi-agent orchestration"
+        },
+        "release_date": {
+            "Kimi-K2.6": "2026-04-20"
         }
     },
     "deepseek": {
@@ -1545,6 +1578,10 @@
         "descriptions": {
             "DeepSeek-V4-Flash": "DeepSeek's efficient MoE model (284B/13B active) with 1M context optimized for fast reasoning and coding",
             "DeepSeek-V4-Pro": "DeepSeek's flagship 1.6T-parameter MoE for complex reasoning, full-codebase analysis, and agentic workflows"
+        },
+        "release_date": {
+            "DeepSeek-V4-Flash": "2026-04-24",
+            "DeepSeek-V4-Pro": "2026-04-24"
         }
     },
     "xiaomi": {
@@ -1594,6 +1631,10 @@
         "descriptions": {
             "MiMo-V2.5": "Xiaomi's omnimodal model (image + video) with 1M context, delivering Pro-level agentic performance at roughly half the cost",
             "MiMo-V2.5-Pro": "Xiaomi's flagship model with 1M context, optimized for agentic tasks, complex software engineering, and long-horizon workflows"
+        },
+        "release_date": {
+            "MiMo-V2.5": "2026-04-22",
+            "MiMo-V2.5-Pro": "2026-04-22"
         }
     },
     "perplexity": {
@@ -1626,6 +1667,9 @@
         },
         "descriptions": {
             "sonar": "Perplexity's latest reasoning & search Model"
+        },
+        "release_date": {
+            "sonar": "2025-01-28"
         }
     },
     "replicate": {
@@ -1795,8 +1839,6 @@
             "grok-imagine-video": "Grok Imagine Video"
         },
         "availableForChatApp": {
-            "grok-3": "Pro",
-            "grok-3-mini": "Free",
             "grok-4-fast": "Free",
             "grok-imagine-video": "Pro",
             "grok-4.3": "Pro"
@@ -1808,7 +1850,14 @@
             "grok-4": "Latest reasoning model from xAI",
             "grok-4-fast": "Low-latency, cost-efficient variant of Grok 4 optimized for speed",
             "grok-4.3": "xAI's flagship reasoning model with strong agentic tool calling and 1M context"
-
+        },
+        "deprecated": [
+            "grok-3",
+            "grok-3-mini",
+            "grok-4"
+        ],
+        "release_date": {
+            "grok-4.3": "2026-05-01"
         }
     },
     "kwaivgi": {


### PR DESCRIPTION
## Summary

Curated per-generation deprecation pass, plus a new `release_date` dict per provider populated from OpenRouter.

**Why curated, not date-based?** I tested 10- and 12-month sliding windows against the user-supplied deprecation list. **The newest model in the list (gpt-5.3-codex) is only 3.7 months old** — no single rolling window cleanly captures the list without false positives. The pattern is "prior major version per provider", not age.

## Deprecation set (30 models)

### NEW — today's spec (17)

| Provider | Model | Release |
| --- | --- | --- |
| openai | gpt-4.1 | 2025-04-14 |
| openai | gpt-4.1-nano | 2025-04-14 |
| openai | gpt-5 | 2025-08-07 |
| openai | gpt-5-mini | 2025-08-07 |
| openai | gpt-5-nano | 2025-08-07 |
| openai | gpt-5.1 | 2025-11-14 |
| openai | gpt-5.1-chat-latest | 2025-11-14 |
| openai | gpt-5.2 | 2025-12-10 |
| openai | gpt-5.2-chat-latest | 2025-12-10 |
| openai | gpt-5.2-pro | 2025-12-10 |
| openai | gpt-5.3-codex | 2026-02-25 |
| anthropic | claude-sonnet-4-20250514 | 2025-05-22 |
| google | gemini-2.5-pro | 2025-06-17 |
| google | gemini-2.5-flash | 2025-06-17 |
| togetherai | Qwen3-30B-A3B | 2025-04-29 |
| togetherai | Kimi-K2-Thinking | 2025-11-06 |
| xai | grok-4 | 2025-07-09 |

### Legacy (13)

**Auto (OR `created` < 2025-03-24): 6**
- openai/gpt-4o (2024-05-13), openai/gpt-4o-mini (2024-07-18)
- anthropic/claude-3-haiku-20240307 (2024-03-13), anthropic/claude-3-5-haiku-20241022 (2024-11-04)
- mistral/mistral-large-latest (2024-02-26)
- togetherai/Meta-Llama-3.1-70B-Instruct-Turbo (2024-07-23)

**Manual (OR removed, clearly old): 7**
- openai/chatgpt-4o-latest, openai/o1-mini
- anthropic/claude-3-5-sonnet-latest
- google/gemini-1.5-pro-latest, google/gemini-2.0-flash
- xai/grok-3, xai/grok-3-mini

### Exception (NOT deprecated, kept in chat-app)

- **perplexity/sonar** — per user request, kept in chat-app despite created date 2025-01-28.

### Slug fixes (6) — `openrouter_identifier` corrections

| Provider/model | Old slug | New slug |
| --- | --- | --- |
| anthropic/claude-haiku-4-5-20251001 | claude-haiku-4.5-20251001 | `anthropic/claude-haiku-4.5` |
| anthropic/claude-sonnet-4-5-20250929 | claude-sonnet-4.5-20250929 | `anthropic/claude-sonnet-4.5` |
| anthropic/claude-opus-4-5-20251101 | claude-opus-4.5-20251101 | `anthropic/claude-opus-4.5` |
| google/gemini-2.5-flash-image-preview | gemini-2.5-flash-image-preview | `google/gemini-2.5-flash-image` |
| togetherai/Qwen3-30B-A3B | Qwen/qwen3-30B-A3B | `qwen/qwen3-30b-a3b` |
| togetherai/Kimi-K2-Thinking | (kept old) | `moonshotai/kimi-k2-thinking` |

### Kept in chat-app without `release_date` (5 — OR doesn't catalog or slug mismatch)

- google/gemini-3-pro-preview, xai/grok-4-fast, xai/grok-imagine-video
- kwaivgi/kling-v3.0-pro, bytedance/seedance-2.0

`release_date` field added to 29 remaining chat-app models (keyed by model ID per provider).

## Sliding-window analysis (for context)

| Window | Extra caught | Missed from user list |
| --- | --- | --- |
| 10 months | 0 | 5 (gpt-5.1+, Kimi-K2-Thinking) |
| 12 months | 0 | 10 (gpt-5+, gemini-2.5, Kimi-K2-Thinking) |
| <4 months | ~25 you want to keep | 0 |

Verdict: stay with the curated list; revisit per-provider when a new major lineup ships.

## Compatibility

`scripts/sync_models.py` reads `availableForChatApp` defensively and doesn't reference `release_date`. **No breakage; new field is a no-op downstream until a follow-up PR adds it to the sync + Prisma schema.**

## Test plan

- [x] `python -m json.tool model_pricing.json` — JSON valid
- [x] No release_date for any deprecated model
- [ ] Manual: `gh workflow run sync-models.yml --ref chore/deprecate-old-models -f env=staging` — confirm staging Supabase sync runs without error

## Follow-ups (not blocking)

- Teach `scripts/sync_models.py` to extract `release_date` and persist it (Prisma migration to add column).
- Verify the 5 no-release-date slugs (`gemini-3-pro-preview`, `grok-4-fast`, video-gen models) at OpenRouter or fix manually.

🤖 Generated with [Claude Code](https://claude.com/claude-code)