### PR TITLE
chore: free-tier flips for sub-$3 models + price syncs + add z-ai/glm-5.2

### DIFF
--- a/model_pricing.json
+++ b/model_pricing.json
@@ -1517,8 +1517,8 @@
         },
         "price": {
             "Kimi-K2.6": {
-                "input": 0.7448,
-                "output": 4.655
+                "input": 0.68,
+                "output": 3.41
             }
         },
         "name": {
@@ -1572,8 +1572,8 @@
             "DeepSeek-V4-Pro": "DeepSeek-V4 Pro"
         },
         "availableForChatApp": {
-            "DeepSeek-V4-Flash": "Pro",
-            "DeepSeek-V4-Pro": "Pro"
+            "DeepSeek-V4-Flash": "Free",
+            "DeepSeek-V4-Pro": "Free"
         },
         "descriptions": {
             "DeepSeek-V4-Flash": "DeepSeek's efficient MoE model (284B/13B active) with 1M context optimized for fast reasoning and coding",
@@ -1612,12 +1612,12 @@
         },
         "price": {
             "MiMo-V2.5": {
-                "input": 0.4,
-                "output": 2
+                "input": 0.14,
+                "output": 0.28
             },
             "MiMo-V2.5-Pro": {
-                "input": 1,
-                "output": 3
+                "input": 0.435,
+                "output": 0.87
             }
         },
         "name": {
@@ -1625,8 +1625,8 @@
             "MiMo-V2.5-Pro": "MiMo-V2.5 Pro"
         },
         "availableForChatApp": {
-            "MiMo-V2.5": "Pro",
-            "MiMo-V2.5-Pro": "Pro"
+            "MiMo-V2.5": "Free",
+            "MiMo-V2.5-Pro": "Free"
         },
         "descriptions": {
             "MiMo-V2.5": "Xiaomi's omnimodal model (image + video) with 1M context, delivering Pro-level agentic performance at roughly half the cost",
@@ -1934,6 +1934,43 @@
         },
         "descriptions": {
             "seedance-2.0": "ByteDance's video generation model with text-to-video, image-to-video with first/last-frame control, and multimodal reference-to-video with strong character and style consistency"
+        }
+    },
+    "z-ai": {
+        "icon": "https://svgl.app/library/zhipu.svg",
+        "sources": [
+            "https://openrouter.ai/z-ai",
+            "https://docs.z.ai"
+        ],
+        "models": [
+            "GLM-5.2"
+        ],
+        "api_key": "ZAI_API_KEY",
+        "capabilities": {
+            "GLM-5.2": [
+                "reasoning"
+            ]
+        },
+        "openrouter_identifier": {
+            "GLM-5.2": "z-ai/glm-5.2"
+        },
+        "price": {
+            "GLM-5.2": {
+                "input": 1.4,
+                "output": 4.4
+            }
+        },
+        "name": {
+            "GLM-5.2": "GLM 5.2"
+        },
+        "availableForChatApp": {
+            "GLM-5.2": "Pro"
+        },
+        "descriptions": {
+            "GLM-5.2": "Z.ai's large-scale reasoning model with 1M-token context, suited for long-horizon agent workflows and project-level software engineering."
+        },
+        "release_date": {
+            "GLM-5.2": "2026-06-16"
         }
     }
 }


### PR DESCRIPTION
## Summary

Three changes bundled, all signed off by the owner:

1. **Pro → Free flips** for 4 text models whose output price is ≤ \$3/M tokens (the new rule).
2. **Price sync to OpenRouter** for 3 entries whose local prices drifted significantly above OR's current numbers.
3. **Add z-ai/glm-5.2** as a new provider (the existing \`moonshotai/Kimi-K2.6\` entry was kept; only its price was synced).

## Pro → Free flips (4)

| Provider/model | Input \$/M | Output \$/M |
| --- | ---: | ---: |
| deepseek/DeepSeek-V4-Flash | \$0.14 | \$0.28 |
| deepseek/DeepSeek-V4-Pro | \$0.435 | \$0.87 |
| xiaomi/MiMo-V2.5 | \$0.14 | \$0.28 |
| xiaomi/MiMo-V2.5-Pro | \$0.435 | \$0.87 |

\`xai/grok-4.3\` (\$1.25 in / \$2.50 out) was inside the < \$3 rule but **kept Pro per owner instruction**.

## Price sync to OpenRouter (3)

| Model | Old in → new in | Old out → new out |
| --- | --- | --- |
| xiaomi/MiMo-V2.5 | \$0.40 → \$0.14 | \$2.00 → \$0.28 *(was 7× OR)* |
| xiaomi/MiMo-V2.5-Pro | \$1.00 → \$0.435 | \$3.00 → \$0.87 *(was 3.4× OR)* |
| moonshotai/Kimi-K2.6 | \$0.7448 → \$0.68 | \$4.655 → \$3.41 |

## New: z-ai provider + GLM-5.2

| Field | Value |
| --- | --- |
| Provider key | \`z-ai\` (new top-level entry) |
| Model ID | \`GLM-5.2\` |
| Display name | GLM 5.2 |
| openrouter_identifier | \`z-ai/glm-5.2\` |
| Input \$/M | \$1.40 |
| Output \$/M | \$4.40 |
| Tier | Pro (output > \$3 per the rule) |
| Context | 1,048,576 (1M tokens) |
| Capabilities | reasoning |
| Release date | 2026-06-16 |
| Source | https://openrouter.ai/z-ai/glm-5.2 |

## Already present (no add needed)

- \`moonshotai/Kimi-K2.6\` was already in the file (Pro, slug \`moonshotai/kimi-k2.6\`). Only its price was synced as part of the sync above.

## Test plan

- [x] \`python -m json.tool model_pricing.json\` → JSON valid
- [x] Sub-\$3 text models in \`availableForChatApp\`: deepseek-v4 family + MiMo family now \"Free\"; xai/grok-4.3 unchanged
- [x] z-ai key exists at the top level alongside \`bytedance\`, \`xai\`, etc.
- [ ] Manual: \`gh workflow run sync-models.yml --ref chore/free-tier-flips-and-glm5 -f env=staging\` — confirm staging Supabase sync runs without error

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added GLM-5.2 model for premium tier users.

* **Updates**
  * Reduced pricing for Kimi-K2.6 model.
  * DeepSeek V4-Flash and V4-Pro models now available on the free tier.
  * Xiaomi MiMo-V2.5 and MiMo-V2.5-Pro models now available on the free tier with reduced pricing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->