### PR TITLE
feat: add Meta Muse Spark 1.1 (LLM Gateway only)

### DIFF
--- a/CAPABILITIES.md
+++ b/CAPABILITIES.md
@@ -1,0 +1,88 @@
+# Model capabilities reference
+
+Each model entry in `model_pricing.json` has a `capabilities` array. These strings drive IronLabs product behavior (chat app filters, routing eligibility, Foundry modes, sync to Supabase). They are **not** all native provider API flags — some are IronLabs-specific markers.
+
+When adding a model, pick capabilities from this list. Do not infer from LiteLLM alone; check a similar model in the same tier or ask in PR review.
+
+---
+
+## IronLabs platform markers
+
+These describe **IronLabs product support**, not something the upstream provider documents on its own.
+
+### `routing`
+
+**Not a native model capability.** Marks whether the model is supported by **IronLabs' LLM-Routing algorithm** — eligible for model-select / tradeoff routing when the user picks a candidate set (cost, latency, performance).
+
+Do **not** add `routing` because a model supports function calling or tools. Only add it when the model is wired into IronLabs routing end-to-end.
+
+### `agent-mode`
+
+Marks models that can be used as **Agent Mode** backends in **Foundry** ([chat.ironlabs.ai](https://chat.ironlabs.ai)) — IronLabs' agentic chat product (internal codename: Cottage). These models are vetted for long-horizon agent workflows (sandbox tool use, multi-step tasks) in Foundry, not merely “supports tools” on the provider API.
+
+---
+
+## Provider-native / feature capabilities
+
+These reflect what the model can do on the wire (inputs, outputs, or provider features IronLabs surfaces).
+
+| Capability | Meaning |
+| --- | --- |
+| `reasoning` | Extended thinking / reasoning effort (chain-of-thought, thinking tokens, or equivalent). Often paired with `reasoning_config.json` for gateway effort mapping. |
+| `image` | Accepts image inputs (vision). |
+| `video` | Accepts video inputs (multimodal). |
+| `pdf` | Accepts PDF document inputs. |
+| `search` | Provider or gateway web search / grounding (e.g. OpenAI search, Perplexity, Gemini search). |
+| `xSearch` | X (Twitter) search integration exposed in Foundry search modes. |
+| `image-gen` | Generates images as output (not just vision input). |
+| `video-gen` | Generates video as output. |
+| `computer-use` | Computer-use / GUI automation style capability (provider-native). |
+| `code-interpreter` | Code interpreter / sandbox execution style capability. |
+| `file-search` | File search / retrieval over uploaded or indexed files. |
+| `agentic` | Provider-marketed agentic behavior (general tag; distinct from IronLabs `agent-mode` eligibility above). |
+
+---
+
+## Examples
+
+**Muse Spark 1.1** (`meta/muse-spark-1.1`):
+
+```json
+"capabilities": [
+  "reasoning",
+  "image",
+  "video",
+  "pdf",
+  "search",
+  "agent-mode"
+]
+```
+
+- No `routing` — not yet enrolled in IronLabs LLM-Routing; routed via LLM Gateway directly.
+- `agent-mode` — eligible as a Foundry Agent Mode model.
+- `reasoning`, `image`, `video`, `pdf`, `search` — native multimodal + reasoning features from the provider/gateway.
+
+**GPT-5.6 Sol** (typical Pro routing + agent model):
+
+```json
+"capabilities": [
+  "reasoning",
+  "image",
+  "search",
+  "pdf",
+  "agent-mode",
+  "routing"
+]
+```
+
+---
+
+## Related files
+
+| File | Role |
+| --- | --- |
+| `model_pricing.json` | Source of truth for capabilities, pricing, chat app metadata |
+| `reasoning_config.json` | Gateway reasoning effort policy per provider/model (separate from this list) |
+| `scripts/sync_models.py` | Syncs capabilities to Supabase for Foundry / Studio |
+
+See [README.md](./README.md) for sync and validation workflow.

--- a/README.md
+++ b/README.md
@@ -53,6 +53,8 @@ python -m json.tool model_pricing.json
 │   ├── sync_models.py           # Python script to sync data to Supabase
 │   └── schema.prisma            # Database schema
 ├── model_pricing.json           # Main data file with LLM pricing info
+├── reasoning_config.json        # Gateway reasoning effort policy per model
+├── CAPABILITIES.md              # What each capability string means
 └── README.md                    # This file
 ```
 
@@ -71,17 +73,10 @@ The sync script requires these Supabase credentials:
 
 ### Adding New Models
 1. Update `model_pricing.json` with new provider/model information
-2. Validate JSON structure: `python -m json.tool model_pricing.json`
-3. Commit and push to `development` branch for staging sync
-4. Merge to `main` branch for production sync
-
-### Capabilities vs `routing`
-
-Each model's `capabilities` array describes **what the model itself supports** (e.g. `reasoning`, `image`, `video`, `pdf`, `search`, `agent-mode`).
-
-**`routing` is not a model capability.** It marks whether a model is supported by **IronLabs' LLM-Routing algorithm** — i.e. eligible for IronLabs model-select / tradeoff routing across a candidate set. Do not add `routing` to a model just because it supports function calling or tools; only add it when the model is wired into IronLabs routing.
-
-Other capability strings map to provider-native features. When in doubt, check an existing model in the same provider tier (see PRs like #31) rather than inferring from LiteLLM flags alone.
+2. Pick capabilities per [CAPABILITIES.md](./CAPABILITIES.md) — especially `routing` vs `agent-mode`
+3. Validate JSON structure: `python -m json.tool model_pricing.json`
+4. Commit and push to `development` branch for staging sync
+5. Merge to `main` branch for production sync
 
 ## Workflow Details
 

--- a/README.md
+++ b/README.md
@@ -75,6 +75,14 @@ The sync script requires these Supabase credentials:
 3. Commit and push to `development` branch for staging sync
 4. Merge to `main` branch for production sync
 
+### Capabilities vs `routing`
+
+Each model's `capabilities` array describes **what the model itself supports** (e.g. `reasoning`, `image`, `video`, `pdf`, `search`, `agent-mode`).
+
+**`routing` is not a model capability.** It marks whether a model is supported by **IronLabs' LLM-Routing algorithm** — i.e. eligible for IronLabs model-select / tradeoff routing across a candidate set. Do not add `routing` to a model just because it supports function calling or tools; only add it when the model is wired into IronLabs routing.
+
+Other capability strings map to provider-native features. When in doubt, check an existing model in the same provider tier (see PRs like #31) rather than inferring from LiteLLM flags alone.
+
 ## Workflow Details
 
 The `sync-models.yml` workflow:

--- a/model_pricing.json
+++ b/model_pricing.json
@@ -2041,7 +2041,6 @@
         "api_key": "META_API_KEY",
         "capabilities": {
             "muse-spark-1.1": [
-                "routing",
                 "image",
                 "video",
                 "pdf",

--- a/model_pricing.json
+++ b/model_pricing.json
@@ -2041,7 +2041,6 @@
         "api_key": "META_API_KEY",
         "capabilities": {
             "muse-spark-1.1": [
-                "routing",
                 "reasoning",
                 "image",
                 "video",

--- a/model_pricing.json
+++ b/model_pricing.json
@@ -2028,5 +2028,44 @@
         "release_date": {
             "GLM-5.2": "2026-06-16"
         }
+    },
+    "meta": {
+        "icon": "https://svgl.app/library/meta.svg",
+        "sources": [
+            "https://llmgateway.io/models/muse-spark-1.1",
+            "https://dev.meta.ai/docs/getting-started/pricing-rate-limits"
+        ],
+        "models": [
+            "muse-spark-1.1"
+        ],
+        "api_key": "META_API_KEY",
+        "capabilities": {
+            "muse-spark-1.1": [
+                "routing",
+                "image",
+                "video",
+                "pdf",
+                "reasoning",
+                "search"
+            ]
+        },
+        "price": {
+            "muse-spark-1.1": {
+                "input": 1.25,
+                "output": 4.25
+            }
+        },
+        "name": {
+            "muse-spark-1.1": "Muse Spark 1.1"
+        },
+        "availableForChatApp": {
+            "muse-spark-1.1": "Pro"
+        },
+        "descriptions": {
+            "muse-spark-1.1": "Meta's multimodal reasoning model built for agentic tool calling, coding, structured output, and long-context workflows with image and video understanding."
+        },
+        "release_date": {
+            "muse-spark-1.1": "2026-07-13"
+        }
     }
 }

--- a/model_pricing.json
+++ b/model_pricing.json
@@ -2041,11 +2041,13 @@
         "api_key": "META_API_KEY",
         "capabilities": {
             "muse-spark-1.1": [
+                "routing",
+                "reasoning",
                 "image",
                 "video",
                 "pdf",
-                "reasoning",
-                "search"
+                "search",
+                "agent-mode"
             ]
         },
         "price": {
@@ -2061,7 +2063,7 @@
             "muse-spark-1.1": "Pro"
         },
         "descriptions": {
-            "muse-spark-1.1": "Meta's multimodal reasoning model built for agentic tool calling, coding, structured output, and long-context workflows with image and video understanding."
+            "muse-spark-1.1": "Meta's 1M-context multimodal reasoning model for agentic tool calling, coding, and structured output with image and video understanding"
         },
         "release_date": {
             "muse-spark-1.1": "2026-07-13"

--- a/reasoning_config.json
+++ b/reasoning_config.json
@@ -345,6 +345,23 @@
           "mandatory": false
         }
       }
+    },
+    "meta": {
+      "models": {
+        "muse-spark-1.1": {
+          "supported_efforts": [
+            "xhigh",
+            "high",
+            "medium",
+            "low",
+            "minimal"
+          ],
+          "default_effort": "medium",
+          "default_enabled": true,
+          "supports_max_tokens": false,
+          "mandatory": false
+        }
+      }
     }
   }
 }


### PR DESCRIPTION
## Summary
- Adds **`meta/muse-spark-1.1`** to `model_pricing.json` under a new `meta` provider
- Pricing from [LLM Gateway](https://llmgateway.io/models/muse-spark-1.1): **$1.25/M** input, **$4.25/M** output
- Capabilities: routing, image, video, pdf, reasoning, search (1M context multimodal reasoning model)
- **No `openrouter_identifier`** — OpenRouter does not list this model yet; requests should route via the primary LLM Gateway only
- Adds gateway reasoning config for `muse-spark-1.1` in `reasoning_config.json` (xhigh → minimal efforts)

## Test plan
- [x] `python3 -m json.tool model_pricing.json` passes
- [x] `python3 -m json.tool reasoning_config.json` passes
- [x] Confirmed OpenRouter model list has no `muse-spark` entry
- [ ] Merge to `development` → auto-syncs to staging Supabase


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for the Meta provider and its Muse Spark 1.1 model.
  * Added model capabilities including image, video, PDF, reasoning, and search.
  * Added pricing, availability, description, and release information.
  * Added configurable reasoning effort settings, enabled by default.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->