### PR TITLE
chore: remove claude-opus-4-7 from Foundry chat app

### DIFF
--- a/model_pricing.json
+++ b/model_pricing.json
@@ -1013,7 +1013,6 @@
             "claude-opus-4-5-20251101": "Pro",
             "claude-sonnet-4-6": "Pro",
             "claude-opus-4-6": "Pro",
-            "claude-opus-4-7": "Pro",
             "claude-opus-4-8": "Pro",
             "claude-sonnet-5": "Pro"
         },


### PR DESCRIPTION
## Summary
- Removes `claude-opus-4-7` from `availableForChatApp` in `model_pricing.json`
- Model remains in pricing/routing data; it will no longer appear in the Foundry chat app model picker after Supabase sync

## Test plan
- [x] `python3 -m json.tool model_pricing.json` passes
- [ ] Merge to `development` → staging sync clears chat app availability for opus-4-7


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Removed Claude Opus 4.7 from the models available in the chat app.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->