### PR TITLE
feat: add Gemini 3.6 Flash, 3.5 Flash Lite, and Claude Opus 5

### DIFF
--- a/model_pricing.json
+++ b/model_pricing.json
@@ -724,7 +724,8 @@
             "claude-opus-4-6",
             "claude-opus-4-7",
             "claude-opus-4-8",
-            "claude-sonnet-5"
+            "claude-sonnet-5",
+            "claude-opus-5"
         ],
         "api_key": "ANTHROPIC_API_KEY",
         "capabilities": {
@@ -868,6 +869,12 @@
                 "computer-use",
                 "reasoning",
                 "agent-mode"
+            ],
+            "claude-opus-5": [
+                "image",
+                "pdf",
+                "reasoning",
+                "agent-mode"
             ]
         },
         "openrouter_identifier": {
@@ -893,7 +900,8 @@
             "claude-opus-4-6": "anthropic/claude-opus-4.6",
             "claude-opus-4-7": "anthropic/claude-opus-4.7",
             "claude-opus-4-8": "anthropic/claude-opus-4.8",
-            "claude-sonnet-5": "anthropic/claude-sonnet-5"
+            "claude-sonnet-5": "anthropic/claude-sonnet-5",
+            "claude-opus-5": "anthropic/claude-opus-5"
         },
         "price": {
             "claude-2.1": {
@@ -991,6 +999,10 @@
             "claude-sonnet-5": {
                 "input": 3,
                 "output": 15
+            },
+            "claude-opus-5": {
+                "input": 5,
+                "output": 25
             }
         },
         "name": {
@@ -1005,7 +1017,8 @@
             "claude-opus-4-6": "Claude-4.6 Opus",
             "claude-opus-4-7": "Claude-4.7 Opus",
             "claude-opus-4-8": "Claude-4.8 Opus",
-            "claude-sonnet-5": "Claude-5 Sonnet"
+            "claude-sonnet-5": "Claude-5 Sonnet",
+            "claude-opus-5": "Claude-5 Opus"
         },
         "availableForChatApp": {
             "claude-haiku-4-5-20251001": "Pro",
@@ -1015,7 +1028,8 @@
             "claude-opus-4-6": "Pro",
             "claude-opus-4-7": "Pro",
             "claude-opus-4-8": "Pro",
-            "claude-sonnet-5": "Pro"
+            "claude-sonnet-5": "Pro",
+            "claude-opus-5": "Pro"
         },
         "alias": {
             "claude-3-5-haiku-20241022": "claude-3-5-haiku",
@@ -1037,7 +1051,8 @@
             "claude-opus-4-6": "The most intelligent model for building agents and coding",
             "claude-opus-4-7": "Highly autonomous Claude model for long-horizon agentic work and coding",
             "claude-opus-4-8": "Anthropic's most capable model for complex reasoning and autonomous agents",
-            "claude-sonnet-5": "The best combination of speed and intelligence for coding and agents"
+            "claude-sonnet-5": "The best combination of speed and intelligence for coding and agents",
+            "claude-opus-5": "Anthropic's flagship Opus model for the most complex reasoning, coding, and autonomous agent work"
         },
         "deprecated": [
             "claude-3-haiku-20240307",
@@ -1053,7 +1068,8 @@
             "claude-opus-4-6": "2026-02-04",
             "claude-opus-4-7": "2026-04-16",
             "claude-opus-4-8": "2026-05-27",
-            "claude-sonnet-5": "2026-06-30"
+            "claude-sonnet-5": "2026-06-30",
+            "claude-opus-5": "2026-07-28"
         }
     },
     "google": {
@@ -1075,6 +1091,8 @@
             "gemini-3.1-pro-preview",
             "gemini-3.1-flash-lite-preview",
             "gemini-3.5-flash",
+            "gemini-3.6-flash",
+            "gemini-3.5-flash-lite",
             "gemini-2.5-flash-image-preview",
             "gemini-3-pro-image-preview",
             "gemini-3.1-flash-image-preview"
@@ -1155,6 +1173,18 @@
                 "reasoning",
                 "video"
             ],
+            "gemini-3.6-flash": [
+                "image",
+                "pdf",
+                "search",
+                "reasoning",
+                "video"
+            ],
+            "gemini-3.5-flash-lite": [
+                "image",
+                "search",
+                "reasoning"
+            ],
             "gemini-2.5-flash-image-preview": [
                 "image",
                 "image-gen"
@@ -1180,6 +1210,8 @@
             "gemini-3.1-pro-preview": "google/gemini-3.1-pro-preview",
             "gemini-3.1-flash-lite-preview": "google/gemini-3.1-flash-lite-preview",
             "gemini-3.5-flash": "google/gemini-3.5-flash",
+            "gemini-3.6-flash": "google/gemini-3.6-flash",
+            "gemini-3.5-flash-lite": "google/gemini-3.5-flash-lite",
             "gemini-2.5-flash-image-preview": "google/gemini-2.5-flash-image",
             "gemini-3-pro-image-preview": "google/gemini-3-pro-image-preview",
             "gemini-3.1-flash-image-preview": "google/gemini-3.1-flash-image-preview"
@@ -1229,6 +1261,14 @@
                 "input": 1.5,
                 "output": 9
             },
+            "gemini-3.6-flash": {
+                "input": 1.5,
+                "output": 7.5
+            },
+            "gemini-3.5-flash-lite": {
+                "input": 0.3,
+                "output": 2.5
+            },
             "gemini-2.5-flash-image-preview": {
                 "input": 0.15,
                 "output": 0.6
@@ -1253,6 +1293,8 @@
             "gemini-3.1-pro-preview": "Gemini-3.1 Pro",
             "gemini-3.1-flash-lite-preview": "Gemini-3.1 Flash Lite",
             "gemini-3.5-flash": "Gemini-3.5 Flash",
+            "gemini-3.6-flash": "Gemini-3.6 Flash",
+            "gemini-3.5-flash-lite": "Gemini-3.5 Flash Lite",
             "gemini-2.5-flash-image-preview": "Nano Banana",
             "gemini-3-pro-image-preview": "Nano Banana Pro",
             "gemini-3.1-flash-image-preview": "Nano Banana 2"
@@ -1262,6 +1304,8 @@
             "gemini-3.1-pro-preview": "Pro",
             "gemini-3.1-flash-lite-preview": "Free",
             "gemini-3.5-flash": "Pro",
+            "gemini-3.6-flash": "Pro",
+            "gemini-3.5-flash-lite": "Free",
             "gemini-2.5-flash-image-preview": "Pro",
             "gemini-3-pro-image-preview": "Pro",
             "gemini-3.1-flash-image-preview": "Pro"
@@ -1277,6 +1321,8 @@
             "gemini-3.1-pro-preview": "Google's latest and most advanced Gemini model with improved reasoning and creativity",
             "gemini-3.1-flash-lite-preview": "Google's lightweight Gemini 3.1 Flash model optimized for speed and efficiency",
             "gemini-3.5-flash": "Google's flash-tier model optimized for coding and parallel agentic execution loops",
+            "gemini-3.6-flash": "Google's latest flash-tier Gemini model with improved multimodal reasoning and agentic performance",
+            "gemini-3.5-flash-lite": "Google's lightweight Gemini 3.5 Flash Lite model optimized for speed and cost efficiency",
             "gemini-2.5-flash-image-preview": "Google's newest img model (Nano Banana)",
             "gemini-3-pro-image-preview": "Google's latest Pro image model (Nano Banana Pro)",
             "gemini-3.1-flash-image-preview": "Google's latest fast image model (Nano Banana 2)"
@@ -1302,6 +1348,8 @@
             "gemini-3.1-pro-preview": "2026-02-19",
             "gemini-3.1-flash-lite-preview": "2026-03-03",
             "gemini-3.5-flash": "2026-05-19",
+            "gemini-3.6-flash": "2026-07-28",
+            "gemini-3.5-flash-lite": "2026-07-28",
             "gemini-2.5-flash-image-preview": "2025-10-08",
             "gemini-3-pro-image-preview": "2025-11-20",
             "gemini-3.1-flash-image-preview": "2026-02-26"

--- a/reasoning_config.json
+++ b/reasoning_config.json
@@ -217,6 +217,19 @@
           "default_enabled": false,
           "supports_max_tokens": false,
           "mandatory": false
+        },
+        "claude-opus-5": {
+          "supported_efforts": [
+            "xhigh",
+            "high",
+            "medium",
+            "low",
+            "minimal"
+          ],
+          "default_effort": "medium",
+          "default_enabled": false,
+          "supports_max_tokens": false,
+          "mandatory": false
         }
       }
     },
@@ -262,6 +275,32 @@
           "mandatory": false
         },
         "gemini-3.5-flash": {
+          "supported_efforts": [
+            "xhigh",
+            "high",
+            "medium",
+            "low",
+            "minimal"
+          ],
+          "default_effort": "medium",
+          "default_enabled": true,
+          "supports_max_tokens": false,
+          "mandatory": false
+        },
+        "gemini-3.6-flash": {
+          "supported_efforts": [
+            "xhigh",
+            "high",
+            "medium",
+            "low",
+            "minimal"
+          ],
+          "default_effort": "medium",
+          "default_enabled": true,
+          "supports_max_tokens": false,
+          "mandatory": false
+        },
+        "gemini-3.5-flash-lite": {
           "supported_efforts": [
             "xhigh",
             "high",


### PR DESCRIPTION
## Summary
Adds three models with `availableForChatApp` matching each predecessor:

| Model | Predecessor | Chat tier | OR ID | Pricing ($/M in/out) |
|---|---|---|---|---|
| `gemini-3.6-flash` | `gemini-3.5-flash` | **Pro** | `google/gemini-3.6-flash` | 1.5 / 7.5 |
| `gemini-3.5-flash-lite` | `gemini-3.1-flash-lite-preview` | **Free** | `google/gemini-3.5-flash-lite` | 0.3 / 2.5 |
| `claude-opus-5` | `claude-opus-4-8` | **Pro** | `anthropic/claude-opus-5` | 5 / 25 |

Capabilities, descriptions, and gateway reasoning config follow each predecessor.

## Test plan
- [x] JSON validation passes
- [ ] Merge to `development` → staging Supabase sync


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added Claude Sonnet 5 and Claude Opus 5 to the available model lineup.
  - Added Gemini 3.6 Flash and Gemini 3.5 Flash Lite.
  - Updated model details, pricing, availability, and release information.
  - Added support for configurable reasoning effort on Claude Opus 5 and Gemini 3.6 Flash, including multiple effort levels.
  - Expanded capabilities such as image, PDF, search, video, reasoning, and agent mode support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->